### PR TITLE
I2C LCD compile option for RPi and BBB

### DIFF
--- a/I2CDeviceLCD.cpp
+++ b/I2CDeviceLCD.cpp
@@ -1,0 +1,162 @@
+// -------------------------------------------------------------------------------------------
+// Port for CubieBoard a library LiquidCrystal version 1.2.1 to drive the PCF8574* I2C
+//
+// @version API 1.0.0
+//
+// @author Kabanov Andrew - andrew3007@kabit.ru
+// -------------------------------------------------------------------------------------------
+
+#include "I2CDeviceLCD.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+#include <linux/i2c-dev.h>
+#include <linux/limits.h>
+
+// ---------------------------------------------------------------------------------------------------------------
+
+I2CDeviceLCD::I2CDeviceLCD()
+   : fileDesc(-1),
+	 _initialised(false), _shadow(0x0), _dirMask(0xFF)
+{
+}
+
+I2CDeviceLCD::~I2CDeviceLCD()
+{
+	close();
+}
+
+bool I2CDeviceLCD::open(uint8_t i2cNumBus, uint8_t i2cDevAddr)
+{
+	if( _initialised )
+	{
+		fprintf(stderr, "File i2c device is already open.");
+		return false;
+	}
+
+	char nameFile[PATH_MAX];
+	snprintf(nameFile, PATH_MAX, "/dev/i2c/%d", i2cNumBus);
+	nameFile[PATH_MAX - 1] = '\0';
+
+	fileDesc = ::open(nameFile, O_WRONLY);
+	if( (fileDesc < 0) && (errno == ENOENT || errno == ENOTDIR) )
+	{
+		snprintf(nameFile, PATH_MAX, "/dev/i2c-%d", i2cNumBus);
+		nameFile[PATH_MAX - 1] = '\0';
+		fileDesc = ::open(nameFile, O_WRONLY);
+	}
+
+	if( fileDesc < 0 )
+	{
+		if( errno == ENOENT )
+		{
+			fprintf(stderr, "Error: Could not open file `/dev/i2c-%d' or `/dev/i2c/%d': %s\n",
+							i2cNumBus, i2cNumBus, strerror(ENOENT));
+		}
+		else
+		{
+			fprintf(stderr, "Error: Could not open file `%s': %s\n", nameFile, strerror(errno));
+			if( errno == EACCES )
+			{
+				fprintf(stderr, "Run as root?\n");
+			}
+		}
+
+		return false;
+	}
+
+	if( ioctl(fileDesc, I2C_SLAVE, i2cDevAddr) < 0 )
+	{
+		fputs("Failed to acquire bus access and/or talk to slave.\n", stderr);
+		return false;
+	}
+
+	_initialised = true;
+	return true;
+}
+
+void I2CDeviceLCD::close()
+{
+	if( _initialised )
+	{
+		::close(fileDesc);
+		fileDesc = -1;
+		_initialised = false;
+	}
+}
+
+// ----------------------------------------------------------- PinMode ---------------------------------------------------------------
+
+//
+// pinMode
+void I2CDeviceLCD::pinMode(uint8_t pin, uint8_t dir)
+{
+	if( _initialised )
+	{
+		if( OUTPUT == dir )
+		{
+			_dirMask &= ~( 1 << pin );
+		}
+		else
+		{
+			_dirMask |= ( 1 << pin );
+		}
+	}
+}
+
+// ------------------------------------------------- Write to I2C-device ---------------------------------------------------
+
+//
+// digitalWrite
+ssize_t I2CDeviceLCD::digitalWrite(uint8_t pin, uint8_t level)
+{
+	uint8_t writeVal;
+	ssize_t ret = -1;
+
+	// Check if initialised and that the pin is within range of the device
+	// -------------------------------------------------------------------
+	if( _initialised && (pin <= 7) )
+	{
+		// Only write to HIGH the port if the port has been configured as
+		// an OUTPUT pin. Add the new state of the pin to the shadow
+		writeVal = (1 << pin) & ~_dirMask;
+		if( level == HIGH )
+		{
+			_shadow |= writeVal;
+		}
+		else
+		{
+			_shadow &= ~writeVal;
+		}
+		ret = writeByte(_shadow);
+	}
+
+	return ret;
+}
+
+//
+// writeByte
+ssize_t I2CDeviceLCD::writeByte(uint8_t value)
+{
+	ssize_t ret = -1;
+
+	if( _initialised )
+	{
+		// Only write HIGH the values of the ports that have been initialised as
+		// outputs updating the output shadow of the device
+		_shadow = ( value & ~(_dirMask) );
+
+		const char* byte = reinterpret_cast<const char*>(&_shadow);
+		ret = write(fileDesc, byte, 1);
+	}
+
+	return ret;
+}

--- a/I2CDeviceLCD.cpp
+++ b/I2CDeviceLCD.cpp
@@ -101,7 +101,7 @@ void I2CDeviceLCD::pinMode(uint8_t pin, uint8_t dir)
 {
 	if( _initialised )
 	{
-		if( OUTPUT == dir )
+		if( OUT == dir )
 		{
 			_dirMask &= ~( 1 << pin );
 		}
@@ -126,7 +126,7 @@ ssize_t I2CDeviceLCD::digitalWrite(uint8_t pin, uint8_t level)
 	if( _initialised && (pin <= 7) )
 	{
 		// Only write to HIGH the port if the port has been configured as
-		// an OUTPUT pin. Add the new state of the pin to the shadow
+		// an output pin. Add the new state of the pin to the shadow
 		writeVal = (1 << pin) & ~_dirMask;
 		if( level == HIGH )
 		{

--- a/I2CDeviceLCD.h
+++ b/I2CDeviceLCD.h
@@ -1,0 +1,58 @@
+// -------------------------------------------------------------------------------------------
+// Port for CubieBoard a library LiquidCrystal version 1.2.1 to drive the PCF8574* I2C
+//
+// @version API 1.0.0
+//
+// @author Kabanov Andrew - andrew3007@kabit.ru
+// -------------------------------------------------------------------------------------------
+
+#ifndef I2C_DEVICE_LCD_H
+#define I2C_DEVICE_LCD_H
+
+#include <unistd.h>
+#include <stdint.h>
+
+// Modes data exchange
+#define LCD_4BIT  1
+#define LCD_8BIT  0
+
+// Direct data exchange
+#define INPUT 0
+#define OUTPUT 1
+
+//Level
+#define HIGH 1
+#define LOW  0
+
+//Backlight
+#define LCD_NOBACKLIGHT 0xFF
+
+class I2CDeviceLCD
+{
+	public:
+		I2CDeviceLCD();
+		~I2CDeviceLCD();
+
+	protected:
+		bool open(uint8_t i2cNumBus, uint8_t i2cDevAddr);
+		void close();
+
+		bool init(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+				  uint8_t fourbitMode, uint8_t rs, uint8_t rw, uint8_t enable,
+				  uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+				  uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
+
+		void pinMode(uint8_t pin, uint8_t dir);
+
+		ssize_t digitalWrite(uint8_t pin, uint8_t level);
+
+	private:
+		int fileDesc;       // File descriptor
+		bool _initialised;  // Initialised object
+		uint8_t _shadow;    // Shadow output
+		uint8_t _dirMask;   // Direction mask
+
+		ssize_t writeByte(uint8_t value);
+};
+
+#endif

--- a/I2CDeviceLCD.h
+++ b/I2CDeviceLCD.h
@@ -17,8 +17,8 @@
 #define LCD_8BIT  0
 
 // Direct data exchange
-#define INPUT 0
-#define OUTPUT 1
+#define IN 0
+#define OUT 1
 
 //Level
 #define HIGH 1

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -1,0 +1,568 @@
+// -------------------------------------------------------------------------------------------
+// Port for CubieBoard a library LiquidCrystal version 1.2.1 to drive the PCF8574* I2C
+//
+// @version API 1.0.0
+//
+// @author Kabanov Andrew - andrew3007@kabit.ru
+// -------------------------------------------------------------------------------------------
+
+#include "LCD.h"
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+// CLASS CONSTRUCTORS AND DESTRUCTOR
+// -----------------------------------------------------------------------------------------------------------------------
+LCD::LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+		 uint8_t rs, uint8_t enable,
+		 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+		 uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)
+{
+	init(i2cNumBus, i2cDevAddr, LCD_8BIT, rs, 255, enable, d0, d1, d2, d3, d4, d5, d6, d7);
+}
+
+LCD::LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+		 uint8_t rs, uint8_t rw, uint8_t enable,
+		 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+		 uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)
+{
+	init(i2cNumBus, i2cDevAddr, LCD_8BIT, rs, rw, enable, d0, d1, d2, d3, d4, d5, d6, d7);
+}
+
+LCD::LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+		 uint8_t rs, uint8_t rw, uint8_t enable,
+		 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3)
+{
+	init(i2cNumBus, i2cDevAddr, LCD_4BIT, rs, rw, enable, d0, d1, d2, d3, 0, 0, 0, 0);
+}
+
+LCD::LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+		 uint8_t rs,  uint8_t enable,
+		 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3)
+{
+	init(i2cNumBus, i2cDevAddr, LCD_4BIT, rs, 255, enable, d0, d1, d2, d3, 0, 0, 0, 0);
+}
+
+// Contructors with backlight control
+LCD::LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+		 uint8_t rs, uint8_t enable,
+		 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+		 uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7,
+		 uint8_t backlightPin, t_backlighPol pol)
+{
+	init(i2cNumBus, i2cDevAddr, LCD_8BIT, rs, 255, enable, d0, d1, d2, d3, d4, d5, d6, d7);
+	setBacklightPin(backlightPin, pol);
+}
+
+LCD::LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+		 uint8_t rs, uint8_t rw, uint8_t enable,
+		 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+		 uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7,
+		 uint8_t backlightPin, t_backlighPol pol)
+{
+	init(i2cNumBus, i2cDevAddr, LCD_8BIT, rs, rw, enable, d0, d1, d2, d3, d4, d5, d6, d7);
+	setBacklightPin(backlightPin, pol);
+}
+
+LCD::LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+		 uint8_t rs, uint8_t rw, uint8_t enable,
+		 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+		 uint8_t backlightPin, t_backlighPol pol)
+{
+	init(i2cNumBus, i2cDevAddr, LCD_4BIT, rs, rw, enable, d0, d1, d2, d3, 0, 0, 0, 0);
+	setBacklightPin(backlightPin, pol);
+}
+
+LCD::LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+		 uint8_t rs, uint8_t enable,
+		 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+		 uint8_t backlightPin, t_backlighPol pol)
+{
+	init(i2cNumBus, i2cDevAddr, LCD_4BIT, rs, 255, enable, d0, d1, d2, d3, 0, 0, 0, 0);
+	setBacklightPin(backlightPin, pol);
+}
+
+LCD::~LCD()
+{
+	close();
+}
+
+// ------------------------------------------------------- Init I2C-device -----------------------------------------------------
+
+// init
+bool LCD::init(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+					 uint8_t fourbitMode, uint8_t rs, uint8_t rw, uint8_t enable,
+					 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+					 uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)
+{
+	if( !open(i2cNumBus, i2cDevAddr) )
+	{
+	   return false;
+	}
+
+	// Initialize the IO pins
+	// -----------------------
+	_rs_pin = rs;
+	_rw_pin = rw;
+	_enable_pin = enable;
+
+	_data_pins[0] = d0;
+	_data_pins[1] = d1;
+	_data_pins[2] = d2;
+	_data_pins[3] = d3;
+	_data_pins[4] = d4;
+	_data_pins[5] = d5;
+	_data_pins[6] = d6;
+	_data_pins[7] = d7;
+
+	// Initialize the IO port direction to OUTPUT
+	// ------------------------------------------
+	uint8_t i;
+	for( i = 0; i < 4; i++ )
+	{
+		pinMode(_data_pins[i], OUTPUT);
+	}
+
+	// Initialize the rest of the ports if it is an 8bit controlled LCD
+	// ----------------------------------------------------------------
+	if( fourbitMode == LCD_4BIT )
+	{
+		for( i = 4; i < 8; i++ )
+		{
+			pinMode(_data_pins[i], OUTPUT);
+		}
+	}
+	pinMode(_rs_pin, OUTPUT);
+
+	// we can save 1 pin by not using RW. Indicate by passing 255 instead of pin#
+	if( _rw_pin != 255 )
+	{
+		pinMode(_rw_pin, OUTPUT);
+	}
+
+	pinMode(_enable_pin, OUTPUT);
+
+	// Initialise displaymode functions to defaults: LCD_1LINE and LCD_5x8DOTS
+	// -------------------------------------------------------------------------
+	if( fourbitMode == LCD_4BIT )
+	{
+		_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
+	}
+	else
+	{
+		_displayfunction = LCD_8BITMODE | LCD_1LINE | LCD_5x8DOTS;
+	}
+
+	// Now we pull both RS and R/W low to begin commands
+	digitalWrite(_rs_pin, LOW);
+	digitalWrite(_enable_pin, LOW);
+
+	if( _rw_pin != 255 )
+	{
+		digitalWrite(_rw_pin, LOW);
+	}
+
+	// Initialise the backlight pin no nothing
+	_backlightPin = LCD_NOBACKLIGHT;
+	_polarity = POSITIVE;
+
+	return true;
+}
+
+//
+// setBacklightPin
+void LCD::setBacklightPin(uint8_t pin, t_backlighPol pol)
+{
+	pinMode(pin, OUTPUT);       // Difine the backlight pin as output
+	_backlightPin = pin;
+	_polarity = pol;
+	setBacklight(BACKLIGHT_OFF);   // Set the backlight low by default
+}
+
+//
+// setBackligh
+void LCD::setBacklight(uint8_t value)
+{
+	// Check if there is a pin assigned to the backlight
+	// ---------------------------------------------------
+	if( _backlightPin != LCD_NOBACKLIGHT )
+	{
+		if( ((value > 0) && (_polarity == POSITIVE)) ||
+			((value == 0) && (_polarity == NEGATIVE)) )
+		{
+			digitalWrite(_backlightPin, HIGH);
+		}
+		else
+		{
+			digitalWrite(_backlightPin, LOW);
+		}
+	}
+}
+
+// PUBLIC METHODS
+// ---------------------------------------------------------------------------
+// When the display powers up, it is configured as follows:
+//
+// 1. Display clear
+// 2. Function set:
+//    DL = 1; 8-bit interface data 
+//    N = 0; 1-line display 
+//    F = 0; 5x8 dot character font 
+// 3. Display on/off control: 
+//    D = 0; Display off 
+//    C = 0; Cursor off 
+//    B = 0; Blinking off 
+// 4. Entry mode set: 
+//    I/D = 1; Increment by 1 
+//    S = 0; No shift 
+// ---------------------------------------------------------------------------
+void LCD::begin(uint8_t cols, uint8_t lines, uint8_t dotsize)
+{
+	if( lines > 1 )
+	{
+		_displayfunction |= LCD_2LINE;
+	}
+	_numlines = lines;
+	_cols = cols;
+
+	// for some 1 line displays you can select a 10 pixel high font
+	// ------------------------------------------------------------
+	if( (dotsize != LCD_5x8DOTS) && (lines == 1) )
+	{
+		_displayfunction |= LCD_5x10DOTS;
+	}
+
+	// SEE PAGE 45/46 FOR INITIALIZATION SPECIFICATION!
+	// according to datasheet, we need at least 40ms after power rises above 2.7V
+	// before sending commands. Arduino can turn on way before 4.5V so we'll wait 
+	// 50
+	// ---------------------------------------------------------------------------
+	usleep(100000); // 100 milliSeconds delay
+
+	//put the LCD into 4 bit or 8 bit mode
+	// -------------------------------------
+	if( !(_displayfunction & LCD_8BITMODE) )
+	{
+		// this is according to the hitachi HD44780 datasheet
+		// figure 24, pg 46
+
+		// we start in 8bit mode, try to set 4 bit mode
+		send(0x03, FOUR_BITS);
+		usleep(4500); // wait min 4.1ms
+
+		// second try
+		send(0x03, FOUR_BITS);
+		usleep(4500); // wait min 4.1ms
+
+		// third go!
+		send(0x03, FOUR_BITS);
+		usleep(150);
+
+		// finally, set to 4-bit interface
+		send(0x02, FOUR_BITS);
+	}
+	else
+	{
+		// this is according to the hitachi HD44780 datasheet
+		// page 45 figure 23
+
+		// Send function set command sequence
+		command(LCD_FUNCTIONSET | _displayfunction);
+		usleep(4500);  // wait more than 4.1ms
+
+		// second try
+		command(LCD_FUNCTIONSET | _displayfunction);
+		usleep(150);
+
+		// third go
+		command(LCD_FUNCTIONSET | _displayfunction);
+	}
+
+	// finally, set # lines, font size, etc.
+	command(LCD_FUNCTIONSET | _displayfunction);
+
+	// turn the display on with no cursor or blinking default
+	_displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
+	display();
+
+	// clear the LCD
+	clear();
+
+	// Initialize to default text direction (for romance languages)
+	_displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
+	// set the entry mode
+	command(LCD_ENTRYMODESET | _displaymode);
+
+	backlight();
+}
+
+// Common LCD Commands
+// ---------------------------------------------------------------------------------------------------------------------
+void LCD::clear()
+{
+	command(LCD_CLEARDISPLAY);             // clear display, set cursor position to zero
+	usleep(HOME_CLEAR_EXEC);   // this command is time consuming
+}
+
+void LCD::home()
+{
+	command(LCD_RETURNHOME);              // set cursor position to zero
+	usleep(HOME_CLEAR_EXEC);  // This command is time consuming
+}
+
+void LCD::setCursor(uint8_t col, uint8_t row)
+{
+	const uint8_t row_offsetsDef[]   = { 0x00, 0x40, 0x14, 0x54 }; // For regular LCDs
+	const uint8_t row_offsetsLarge[] = { 0x00, 0x40, 0x10, 0x50 }; // For 16x4 LCDs
+
+	if( row >= _numlines ) 
+	{
+		row = _numlines-1;    // rows start at 0
+	}
+
+	// 16x4 LCDs have special memory map layout
+	// ----------------------------------------
+	if( (_cols == 16) && (_numlines == 4) )
+	{
+		command(LCD_SETDDRAMADDR | (col + row_offsetsLarge[row]));
+	}
+	else
+	{
+		command(LCD_SETDDRAMADDR | (col + row_offsetsDef[row]));
+	}
+}
+
+// Turn the display on/off
+void LCD::noDisplay()
+{
+	_displaycontrol &= ~LCD_DISPLAYON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+
+void LCD::display()
+{
+	_displaycontrol |= LCD_DISPLAYON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+
+// Turns the underline cursor on/off
+void LCD::noCursor()
+{
+	_displaycontrol &= ~LCD_CURSORON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+
+void LCD::cursor()
+{
+	_displaycontrol |= LCD_CURSORON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+
+// Turns on/off the blinking cursor
+void LCD::noBlink()
+{
+	_displaycontrol &= ~LCD_BLINKON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+
+void LCD::blink()
+{
+	_displaycontrol |= LCD_BLINKON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+
+// These commands scroll the display without changing the RAM
+void LCD::scrollDisplayLeft()
+{
+	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVELEFT);
+}
+
+void LCD::scrollDisplayRight()
+{
+	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVERIGHT);
+}
+
+// This is for text that flows Left to Right
+void LCD::leftToRight()
+{
+	_displaymode |= LCD_ENTRYLEFT;
+	command(LCD_ENTRYMODESET | _displaymode);
+}
+
+// This is for text that flows Right to Left
+void LCD::rightToLeft()
+{
+	_displaymode &= ~LCD_ENTRYLEFT;
+	command(LCD_ENTRYMODESET | _displaymode);
+}
+
+// This method moves the cursor one space to the right
+void LCD::moveCursorRight()
+{
+	command(LCD_CURSORSHIFT | LCD_CURSORMOVE | LCD_MOVERIGHT);
+}
+
+// This method moves the cursor one space to the left
+void LCD::moveCursorLeft()
+{
+	command(LCD_CURSORSHIFT | LCD_CURSORMOVE | LCD_MOVELEFT);
+}
+
+
+// This will 'right justify' text from the cursor
+void LCD::autoscroll()
+{
+	_displaymode |= LCD_ENTRYSHIFTINCREMENT;
+	command(LCD_ENTRYMODESET | _displaymode);
+}
+
+// This will 'left justify' text from the cursor
+void LCD::noAutoscroll()
+{
+	_displaymode &= ~LCD_ENTRYSHIFTINCREMENT;
+	command(LCD_ENTRYMODESET | _displaymode);
+}
+
+// Write to CGRAM of new characters
+void LCD::createChar(uint8_t location, uint8_t charmap[])
+{
+	location &= 0x7; // we only have 8 locations 0-7
+
+	command(LCD_SETCGRAMADDR | (location << 3));
+	usleep(30);
+
+	for(int i = 0; i < 8; i++)
+	{
+		write(charmap[i]);
+		usleep(40);
+	}
+}
+
+//
+// Switch on the backlight
+void LCD::backlight()
+{
+	setBacklight(255);
+}
+
+//
+// Switch off the backlight
+void LCD::noBacklight()
+{
+	setBacklight(0);
+}
+
+//
+// Switch fully on the LCD (backlight and LCD)
+void LCD::on()
+{
+	display();
+	backlight();
+}
+
+//
+// Switch fully off the LCD (backlight and LCD) 
+void LCD::off()
+{
+	noBacklight();
+	noDisplay();
+}
+
+// ------------------------------------------------------------ Print text --------------------------------------------------------------
+void LCD::command(uint8_t value)
+{
+	send(value, COMMAND);
+}
+
+ssize_t LCD::write(uint8_t value)
+{
+	return send(value, DATA);
+}
+
+int LCD::print(const char* text)
+{
+	const char* ptr = text;
+	int i;
+	while( *ptr != '\0' )
+	{
+		i = write(*ptr);
+		if( i < 1 )
+		{
+			break;
+		}
+		else
+		{
+			ptr++;
+		}
+	}
+	return ptr - text;
+}
+
+// ---------------------------------------------------- Low level push data to I2C-device --------------------------------------------
+//
+// send
+ssize_t LCD::send(uint8_t value, uint8_t mode)
+{
+	// Only interested in COMMAND or DATA
+	ssize_t ret = digitalWrite(_rs_pin, (mode == DATA));
+	if( ret == -1 )	return (-1);
+
+	// if there is a RW pin indicated, set it low to Write
+	// ---------------------------------------------------
+	if( _rw_pin != 255 )
+	{
+		ret = digitalWrite(_rw_pin, LOW);
+		if( ret == -1 )	return (-1);
+	}
+
+	if( mode != FOUR_BITS )
+	{
+		if( (_displayfunction & LCD_8BITMODE) )
+		{
+			ret = writeNbits(value, 8);
+			if( ret == -1 )	return (-1);
+		}
+		else
+		{
+			ret = writeNbits(value >> 4, 4);
+			if( ret == -1 )	return (-1);
+			ret = writeNbits(value, 4);
+			if( ret == -1 )	return (-1);
+		}
+	}
+	else
+	{
+		ret = writeNbits(value, 4);
+		if( ret == -1 )	return (-1);
+	}
+	waitUsec(TIME_EXEC_COMMAND_BY_LCD); // wait for the command to execute by the LCD
+
+	return 1;
+}
+
+//
+// write4bits
+ssize_t LCD::writeNbits(uint8_t value, uint8_t numBits)
+{
+	ssize_t ret = -1;
+
+	for(uint8_t i = 0; i < numBits; i++)
+	{
+		ret = digitalWrite(_data_pins[i], (value >> i) & 0x01);
+		if( ret == -1 ) return (-1);
+	}
+	pulseEnable();
+
+	return numBits;
+}
+
+//
+// pulseEnable
+void LCD::pulseEnable()
+{
+	// There is no need for the delays, since the digitalWrite operation
+	// takes longer.
+	digitalWrite(_enable_pin, HIGH);
+	waitUsec(1);          // enable pulse must be > 450ns
+	digitalWrite(_enable_pin, LOW);
+}

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -115,12 +115,12 @@ bool LCD::init(uint8_t i2cNumBus, uint8_t i2cDevAddr,
 	_data_pins[6] = d6;
 	_data_pins[7] = d7;
 
-	// Initialize the IO port direction to OUTPUT
+	// Initialize the IO port direction to output
 	// ------------------------------------------
 	uint8_t i;
 	for( i = 0; i < 4; i++ )
 	{
-		pinMode(_data_pins[i], OUTPUT);
+		pinMode(_data_pins[i], OUT);
 	}
 
 	// Initialize the rest of the ports if it is an 8bit controlled LCD
@@ -129,18 +129,18 @@ bool LCD::init(uint8_t i2cNumBus, uint8_t i2cDevAddr,
 	{
 		for( i = 4; i < 8; i++ )
 		{
-			pinMode(_data_pins[i], OUTPUT);
+			pinMode(_data_pins[i], OUT);
 		}
 	}
-	pinMode(_rs_pin, OUTPUT);
+	pinMode(_rs_pin, OUT);
 
 	// we can save 1 pin by not using RW. Indicate by passing 255 instead of pin#
 	if( _rw_pin != 255 )
 	{
-		pinMode(_rw_pin, OUTPUT);
+		pinMode(_rw_pin, OUT);
 	}
 
-	pinMode(_enable_pin, OUTPUT);
+	pinMode(_enable_pin, OUT);
 
 	// Initialise displaymode functions to defaults: LCD_1LINE and LCD_5x8DOTS
 	// -------------------------------------------------------------------------
@@ -173,7 +173,7 @@ bool LCD::init(uint8_t i2cNumBus, uint8_t i2cDevAddr,
 // setBacklightPin
 void LCD::setBacklightPin(uint8_t pin, t_backlighPol pol)
 {
-	pinMode(pin, OUTPUT);       // Difine the backlight pin as output
+	pinMode(pin, OUT);       // Define the backlight pin as output
 	_backlightPin = pin;
 	_polarity = pol;
 	setBacklight(BACKLIGHT_OFF);   // Set the backlight low by default

--- a/LCD.h
+++ b/LCD.h
@@ -1,0 +1,460 @@
+// -------------------------------------------------------------------------------------------
+// Port for CubieBoard a library LiquidCrystal version 1.2.1 to drive the PCF8574* I2C
+//
+// @version API 1.0.0
+//
+// @author Kabanov Andrew - andrew3007@kabit.ru
+// -------------------------------------------------------------------------------------------
+
+#ifndef LCD_H
+#define LCD_H
+
+#include "I2CDeviceLCD.h"
+
+/*!
+	@defined
+	@abstract   Enables disables fast waits for write operations for LCD
+	@discussion If defined, the library will avoid doing un-necessary waits.
+	this can be done, because the time taken by Arduino's slow digitalWrite
+	operations. If fast digitalIO operations, comment this line out or undefine
+	the mode.
+*/
+#define FAST_MODE
+
+/*!
+	@function
+	@abstract   waits for a given time in microseconds (compilation dependent).
+	@discussion Waits for a given time defined in microseconds depending on
+	the FAST_MODE define. If the FAST_MODE is defined the call will return
+	inmediatelly.
+	@param      uSec[in] time in microseconds.
+	@result     None
+*/
+inline static void waitUsec(uint16_t uSec)
+{
+#ifndef FAST_MODE
+   usleep(uSec);
+#endif
+}
+
+// LCD Commands
+// ---------------------------------------------------------------------------
+#define LCD_CLEARDISPLAY        0x01
+#define LCD_RETURNHOME          0x02
+#define LCD_ENTRYMODESET        0x04
+#define LCD_DISPLAYCONTROL      0x08
+#define LCD_CURSORSHIFT         0x10
+#define LCD_FUNCTIONSET         0x20
+#define LCD_SETCGRAMADDR        0x40
+#define LCD_SETDDRAMADDR        0x80
+
+// flags for display entry mode
+// ---------------------------------------------------------------------------
+#define LCD_ENTRYRIGHT          0x00
+#define LCD_ENTRYLEFT           0x02
+#define LCD_ENTRYSHIFTINCREMENT 0x01
+#define LCD_ENTRYSHIFTDECREMENT 0x00
+
+// flags for display on/off and cursor control
+// ---------------------------------------------------------------------------
+#define LCD_DISPLAYON           0x04
+#define LCD_DISPLAYOFF          0x00
+#define LCD_CURSORON            0x02
+#define LCD_CURSOROFF           0x00
+#define LCD_BLINKON             0x01
+#define LCD_BLINKOFF            0x00
+
+// flags for display/cursor shift
+// ---------------------------------------------------------------------------
+#define LCD_DISPLAYMOVE         0x08
+#define LCD_CURSORMOVE          0x00
+#define LCD_MOVERIGHT           0x04
+#define LCD_MOVELEFT            0x00
+
+// flags for function set
+// ---------------------------------------------------------------------------
+#define LCD_8BITMODE            0x10
+#define LCD_4BITMODE            0x00
+#define LCD_2LINE               0x08
+#define LCD_1LINE               0x00
+#define LCD_5x10DOTS            0x04
+#define LCD_5x8DOTS             0x00
+
+// Define COMMAND and DATA LCD Rs (used by send method).
+// ---------------------------------------------------------------------------
+#define COMMAND                 0
+#define DATA                    1
+#define FOUR_BITS               2
+
+// Time exec command by LCD in micro-seconds
+#define TIME_EXEC_COMMAND_BY_LCD 37
+
+/*!
+ @defined 
+ @abstract   Defines the duration of the home and clear commands
+ @discussion This constant defines the time it takes for the home and clear
+ commands in the LCD - Time in microseconds.
+ */
+#define HOME_CLEAR_EXEC      2000
+
+/*!
+    @defined 
+    @abstract   Backlight off constant declaration
+    @discussion Used in combination with the setBacklight to swith off the
+ LCD backlight. @set setBacklight
+*/
+#define BACKLIGHT_OFF         0
+
+/*!
+ @defined 
+ @abstract   Backlight on constant declaration
+ @discussion Used in combination with the setBacklight to swith on the
+ LCD backlight. @set setBacklight
+ */
+#define BACKLIGHT_ON          255
+
+/*!
+ @typedef
+ @abstract   Define backlight control polarity
+ @discussion Backlight control polarity. @see setBacklightPin.
+ */
+typedef enum { POSITIVE, NEGATIVE } t_backlighPol;
+
+
+class LCD : public I2CDeviceLCD
+{
+	public:
+		/*!
+			@method
+			@abstract 8 bit LCD constructors.
+			@discussion Defines the pin assignment that the LCD will have.
+			The constructor does not initialize the LCD.
+		*/
+		LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+			uint8_t rs, uint8_t enable,
+			uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+			uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
+
+		LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+			uint8_t rs, uint8_t rw, uint8_t enable,
+			uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+			uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
+
+		// Constructors with backlight control
+		LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+			uint8_t rs, uint8_t enable,
+			uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+			uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7,
+			uint8_t backlightPin, t_backlighPol pol);
+
+		LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+			uint8_t rs, uint8_t rw, uint8_t enable,
+			uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+			uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7,
+			uint8_t backlightPin, t_backlighPol pol);
+
+		/*!
+			@method
+			@abstract 4 bit LCD constructors.
+			@discussion Defines the pin assignment that the LCD will have.
+			The constructor does not initialize the LCD.
+		*/
+		LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+			uint8_t rs, uint8_t rw, uint8_t enable,
+			uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3);
+
+		LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+			uint8_t rs, uint8_t enable,
+			uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3);
+
+		// Constructors with backlight control
+		LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+			uint8_t rs, uint8_t rw, uint8_t enable,
+			uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+			uint8_t backlightPin, t_backlighPol pol);
+
+		LCD(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+			uint8_t rs, uint8_t enable,
+			uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+			uint8_t backlightPin, t_backlighPol pol);
+
+		/*!
+			@method
+			@abstract LCD destructor.
+		*/
+		~LCD();
+
+		/*!
+			@function
+			@abstract  LCD initialization.
+			@discussion Initializes the LCD to a given size (col, row). This methods
+			initializes the LCD, therefore, it MUST be called prior to using any other
+			method from this class.
+
+			This method is abstract, a base implementation is available common to all LCD
+			drivers. Should it not be compatible with some other LCD driver, a derived
+			implementation should be done on the driver specif class.
+
+			@param  cols[in] the number of columns that the display has
+			@param  rows[in] the number of rows that the display has
+			@param  charsize[in] character size, default==LCD_5x8DOTS
+		*/
+		void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS);
+
+		/*!
+			@function
+			@abstract   Clears the LCD.
+			@discussion Clears the LCD screen and positions the cursor in the upper-left corner.
+			This operation is time consuming for the LCD.
+			@param  none
+		*/
+		void clear();
+
+		/*!
+			@function
+			@abstract Sets the cursor to the upper-left corner.
+			@discussion Positions the cursor in the upper-left of the LCD.
+			That is, use that location in outputting subsequent text to the display.
+			To also clear the display, use the clear() function instead.
+			This operation is time consuming for the LCD.
+			@param none
+		*/
+		void home();
+
+		/*!
+			@function
+			@abstract   Turns off the LCD display.
+			@discussion Turns off the LCD display, without losing the text currently 
+			being displayed on it.
+			@param  none
+		*/
+		void noDisplay();
+
+		/*!
+			@function
+			@abstract   Turns on the LCD display.
+			@discussion Turns on the LCD display, after it's been turned off with 
+			noDisplay(). This will restore the text (and cursor location) that was on 
+			the display prior to calling noDisplay().
+			@param  none
+		*/
+		void display();
+
+		/*!
+			@function
+			@abstract Turns off the blinking of the LCD cursor.
+			@param  none
+		*/
+		void noBlink();
+
+		/*!
+			@function
+			@abstract   Display the cursor of the LCD.
+			@discussion Display the blinking LCD cursor. If used in combination with 
+			the cursor() function, the result will depend on the particular display.
+			@param  none
+		*/
+		void blink();
+
+		/*!
+			@function
+			@abstract   Hides the LCD cursor.
+			@param  none
+		*/
+		void noCursor();
+
+		/*!
+			@function
+			@abstract Display the LCD cursor.
+			@discussion Display the LCD cursor: an underscore (line) at the location 
+			where the next character will be written.
+			@param none
+		*/
+		void cursor();
+
+		/*!
+			@function
+			@abstract Scrolls the contents of the display (text and cursor) one space 
+			to the left.
+			@param none
+		*/
+		void scrollDisplayLeft();
+
+		/*!
+			@function
+			@abstract Scrolls the contents of the display (text and cursor) one space 
+			to the right.
+			@param none
+		*/
+		void scrollDisplayRight();
+
+		/*!
+			@function
+			@abstract Turns on automatic scrolling of the LCD.
+			@discussion Turns on automatic scrolling of the LCD. This causes each 
+			character output to the display to push previous characters over by one 
+			space. If the current text direction is left-to-right (the default), 
+			the display scrolls to the left; if the current direction is right-to-left, 
+			the display scrolls to the right. 
+			This has the effect of outputting each new character to the same location on 
+			the LCD.
+			@param none
+		*/
+		void autoscroll();
+
+		/*!
+			@function
+			@abstract Turns off automatic scrolling of the LCD.
+			@discussion Turns off automatic scrolling of the LCD, this is the default
+			configuration of the LCD.
+			@param none
+		*/
+		void noAutoscroll();
+
+		/*!
+			@function
+			@abstract Set the direction for text written to the LCD to left-to-right.
+			@discussion Set the direction for text written to the LCD to left-to-right. 
+			All subsequent characters written to the display will go from left to right, 
+			but does not affect previously-output text.
+
+			This is the default configuration.
+			@param none
+		*/
+		void leftToRight();
+
+		/*!
+			@function
+			@abstract Set the direction for text written to the LCD to right-to-left.
+			@discussion Set the direction for text written to the LCD to right-to-left. 
+			All subsequent characters written to the display will go from right to left, 
+			but does not affect previously-output text.
+
+			left-to-right is the default configuration.
+			@param none
+		*/
+		void rightToLeft();
+
+		/*!
+			@function
+			@abstract Moves the cursor one space to the left.
+			@discussion 
+			@param none
+		*/
+		void moveCursorLeft();
+
+		/*!
+			@function
+			@abstract Moves the cursor one space to the right.
+			@param none
+		*/
+		void moveCursorRight();
+
+		/*!
+			@function
+			@abstract Creates a custom character for use on the LCD.
+			@discussion Create a custom character (glyph) for use on the LCD. 
+			Most chipsets only support up to eight characters of 5x8 pixels. Therefore,
+			this methods has been limited to locations (numbered 0 to 7). 
+
+			The appearance of each custom character is specified by an array of eight 
+			bytes, one for each row. The five least significant bits of each byte 
+			determine the pixels in that row. To display a custom character on screen, 
+			write()/print() its number, i.e. lcd.print (char(x)); // Where x is 0..7.
+
+			@param      location[in] LCD memory location of the character to create
+						(0 to 7)
+			@param      charmap[in] the bitmap array representing each row of the character.
+		*/
+		void createChar(uint8_t location, uint8_t charmap[]);
+
+		/*!
+			@function
+			@abstract   Position the LCD cursor.
+			@discussion Sets the position of the LCD cursor. Set the location at which 
+			subsequent text written to the LCD will be displayed.
+
+			@param      col[in] LCD column
+			@param      row[in] LCD row - line.
+		*/
+		void setCursor(uint8_t col, uint8_t row);
+
+		/*!
+			@function
+			@abstract   Switch-on the LCD backlight.
+			@discussion Switch-on the LCD backlight.
+			The setBacklightPin has to be called before setting the backlight for
+			this method to work. @see setBacklightPin.
+		*/
+		void backlight();
+
+		/*!
+			@function
+			@abstract   Switch-off the LCD backlight.
+			@discussion Switch-off the LCD backlight.
+			The setBacklightPin has to be called before setting the backlight for
+			this method to work. @see setBacklightPin.
+		*/
+		void noBacklight();
+
+		/*!
+			@function
+			@abstract   Switch on the LCD module.
+			@discussion Switch on the LCD module, it will switch on the LCD controller
+			and the backlight. This method has the same effect of calling display and
+			backlight. @see display, @see backlight
+		*/
+		void on();
+
+		/*!
+			@function
+			@abstract   Switch off the LCD module.
+			@discussion Switch off the LCD module, it will switch off the LCD controller
+			and the backlight. This method has the same effect of calling noDisplay and
+			noBacklight. @see display, @see backlight
+		*/
+		void off();
+
+		/*!
+			@function
+			@abstract Write one char.
+		*/
+		ssize_t write(uint8_t value);
+
+		/*!
+			@function
+			@abstract Print text.
+		*/
+		int print(const char* text);
+
+	private:
+		uint8_t _rs_pin;       // LOW: command.  HIGH: character.
+		uint8_t _rw_pin;       // LOW: write to LCD.  HIGH: read from LCD.
+		uint8_t _enable_pin;   // activated by a HIGH pulse.
+		uint8_t _data_pins[8]; // Data pins.
+		uint8_t _backlightPin; // Pin associated to control the LCD backlight
+
+		uint8_t _displayfunction;  // LCD_5x10DOTS or LCD_5x8DOTS, LCD_4BITMODE or 
+                                   // LCD_8BITMODE, LCD_1LINE or LCD_2LINE
+		uint8_t _displaycontrol;   // LCD base control command LCD on/off, blink, cursor
+                                   // all commands are "ored" to its contents.
+		uint8_t _displaymode;      // Text entry mode to the LCD
+		uint8_t _numlines;         // Number of lines of the LCD, initialized with begin()
+		uint8_t _cols;             // Number of columns in the LCD
+		t_backlighPol _polarity;   // Backlight polarity
+
+		bool init(uint8_t i2cNumBus, uint8_t i2cDevAddr,
+				  uint8_t fourbitMode, uint8_t rs, uint8_t rw, uint8_t enable,
+				  uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+				  uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
+
+		void setBacklight(uint8_t value);
+		void setBacklightPin(uint8_t pin, t_backlighPol pol);
+
+		void command(uint8_t value);
+		ssize_t send(uint8_t value, uint8_t mode);
+		ssize_t writeNbits(uint8_t value, uint8_t numBits);
+		void pulseEnable();
+};
+
+#endif

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -52,8 +52,10 @@ byte OpenSprinkler::water_percent_avg;
 char tmp_buffer[TMP_BUFFER_SIZE+1];       // scratch buffer
 
 #if defined(ARDUINO)
+  #define _BIN B                          // Arduino binary literal format
   LiquidCrystal OpenSprinkler::lcd;
-#elif defined(OSPI)
+#elif defined(RPI-BBB-LCD)
+  #define _BIN 0b                         // C++ binary literal format
   // todo: LCD define for OSPi
 #endif
 
@@ -409,44 +411,44 @@ void OpenSprinkler::begin() {
 
   // define lcd custom icons
   byte lcd_wifi_char[8] = {
-    B00000,
-    B10100,
-    B01000,
-    B10101,
-    B00001,
-    B00101,
-    B00101,
-    B10101
+    _BIN00000,
+    _BIN10100,
+    _BIN01000,
+    _BIN10101,
+    _BIN00001,
+    _BIN00101,
+    _BIN00101,
+    _BIN10101
   };
   byte lcd_sd_char[8] = {
-    B00000,
-    B00000,
-    B11111,
-    B10001,
-    B11111,
-    B10001,
-    B10011,
-    B11110
+    _BIN00000,
+    _BIN00000,
+    _BIN11111,
+    _BIN10001,
+    _BIN11111,
+    _BIN10001,
+    _BIN10011,
+    _BIN11110
   };
   byte lcd_rain_char[8] = {
-    B00000,
-    B00000,
-    B00110,
-    B01001,
-    B11111,
-    B00000,
-    B10101,
-    B10101
+    _BIN00000,
+    _BIN00000,
+    _BIN00110,
+    _BIN01001,
+    _BIN11111,
+    _BIN00000,
+    _BIN10101,
+    _BIN10101
   };
   byte lcd_connect_char[8] = {
-    B00000,
-    B00000,
-    B00111,
-    B00011,
-    B00101,
-    B01000,
-    B10000,
-    B00000
+    _BIN00000,
+    _BIN00000,
+    _BIN00111,
+    _BIN00011,
+    _BIN00101,
+    _BIN01000,
+    _BIN10000,
+    _BIN00000
   };
   lcd.createChar(1, lcd_wifi_char);
   lcd_wifi_char[1]=0;

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -25,7 +25,7 @@
 #ifndef _OPENSPRINKLER_H
 #define _OPENSPRINKLER_H
 
-#if defined(ARDUINO) // heades for AVR
+#if defined(ARDUINO) // headers for AVR
   #include "Arduino.h"
   #include <avr/eeprom.h>
   #include <Wire.h>
@@ -34,6 +34,19 @@
   #include "DS1307RTC.h"
   #include "EtherCard.h"
 #else // headers for RPI/BBB/LINUX
+    #if defined((RPI-BBB-LCD)
+      #include "LCD.h"
+      #define I2C_DEV_ADDR 0x20	// PUT YOUR I2C LCD BACKPACK ADDRESS HERE!
+      #define I2C_NUM_BUS 1		// 0 for RPi B rev 1, 1 for pretty much all else
+      #define RS_PIN 6
+      #define RW_PIN 5
+      #define EN_PIN 4
+      #define BL_PIN 7
+      #define D4_PIN 0
+      #define D5_PIN 1
+      #define D6_PIN 2
+      #define D7_PIN 3
+    #endif
   #include <stdio.h>
   #include <stdlib.h>
   #include <string.h>
@@ -85,10 +98,10 @@ class OpenSprinkler {
 public:
 
   // data members
-#if defined(ARDUINO)
+#if defined(ARDUINO) || (RPI-BBB-LCD)
   static LiquidCrystal lcd;
-#else
-  // todo: LCD define for RPI
+#elif defined(RPI-BBB-LCD)
+  static LCD lcd;
 #endif
 
   static NVConData nvdata;
@@ -162,7 +175,7 @@ public:
   static void apply_all_station_bits(); // apply all station bits (activate/deactive values)
 
   // -- LCD functions
-#if defined(ARDUINO) // LCD functions for Arduino
+#if defined(ARDUINO) || (RPI-BBB-LCD) // LCD functions for AVR/RPi/BBB
   static void lcd_print_pgm(PGM_P PROGMEM str);           // print a program memory string
   static void lcd_print_line_clear_pgm(PGM_P PROGMEM str, byte line);
   static void lcd_print_time(byte line);                  // print current time
@@ -171,20 +184,26 @@ public:
   static void lcd_print_station(byte line, char c);       // print station bits of the board selected by display_board
   static void lcd_print_version(byte v);                   // print version number
 
-  // -- UI and buttons
-  static byte button_read(byte waitmode); // Read button value. options for 'waitmodes' are:
-                                          // BUTTON_WAIT_NONE, BUTTON_WAIT_RELEASE, BUTTON_WAIT_HOLD
-                                          // return values are 'OR'ed with flags
-                                          // check defines.h for details
-
-  // -- UI functions --
-  static void ui_set_options(int oid);    // ui for setting options (oid-> starting option index)
-  static void lcd_set_brightness();
-  static void lcd_set_contrast();
+  #if defined(ARDUINO) // UI functions for AVR
+    // -- UI and buttons
+    static byte button_read(byte waitmode); // Read button value. options for 'waitmodes' are:
+                                            // BUTTON_WAIT_NONE, BUTTON_WAIT_RELEASE, BUTTON_WAIT_HOLD
+                                            // return values are 'OR'ed with flags
+                                            // check defines.h for details
+  
+    // -- UI functions --
+    static void ui_set_options(int oid);    // ui for setting options (oid-> starting option index)
+    static void lcd_set_brightness();
+    static void lcd_set_contrast();
+  #endif
+#endif
 private:
+#if defined(ARDUINO) || (RPI-BBB-LCD) // LCD functions for AVR/RPi/BBB
   static void lcd_print_option(int i);  // print an option to the lcd
   static void lcd_print_2digit(int v);  // print a integer in 2 digits
-  static byte button_read_busy(byte pin_butt, byte waitmode, byte butt, byte is_holding);
+  #if defined(ARDUINO) // UI functions for AVR
+    static byte button_read_busy(byte pin_butt, byte waitmode, byte butt, byte is_holding);
+  #endif
 #endif // LCD functions
 };
 

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -34,7 +34,7 @@
   #include "DS1307RTC.h"
   #include "EtherCard.h"
 #else // headers for RPI/BBB/LINUX
-    #if defined((RPI-BBB-LCD)
+    #if defined(RPIBBBLCD)
       #include "LCD.h"
       #define I2C_DEV_ADDR 0x20	// PUT YOUR I2C LCD BACKPACK ADDRESS HERE!
       #define I2C_NUM_BUS 1		// 0 for RPi B rev 1, 1 for pretty much all else
@@ -98,9 +98,9 @@ class OpenSprinkler {
 public:
 
   // data members
-#if defined(ARDUINO) || (RPI-BBB-LCD)
+#if defined(ARDUINO)
   static LiquidCrystal lcd;
-#elif defined(RPI-BBB-LCD)
+#elif defined(RPIBBBLCD)
   static LCD lcd;
 #endif
 
@@ -175,7 +175,7 @@ public:
   static void apply_all_station_bits(); // apply all station bits (activate/deactive values)
 
   // -- LCD functions
-#if defined(ARDUINO) || (RPI-BBB-LCD) // LCD functions for AVR/RPi/BBB
+#if defined(ARDUINO) || (RPIBBBLCD) // LCD functions for AVR/RPi/BBB
   static void lcd_print_pgm(PGM_P PROGMEM str);           // print a program memory string
   static void lcd_print_line_clear_pgm(PGM_P PROGMEM str, byte line);
   static void lcd_print_time(byte line);                  // print current time
@@ -198,7 +198,7 @@ public:
   #endif
 #endif
 private:
-#if defined(ARDUINO) || (RPI-BBB-LCD) // LCD functions for AVR/RPi/BBB
+#if defined(ARDUINO) || (RPIBBBLCD) // LCD functions for AVR/RPi/BBB
   static void lcd_print_option(int i);  // print an option to the lcd
   static void lcd_print_2digit(int v);  // print a integer in 2 digits
   #if defined(ARDUINO) // UI functions for AVR

--- a/main.cpp
+++ b/main.cpp
@@ -64,7 +64,7 @@ ProgramData pd;   // ProgramdData object
 
 // ====== UI defines ======
 
-#if defined(ARDUINO) || (RPI-BBB-LCD)
+#if defined(ARDUINO) || (RPIBBBLCD)
 static char ui_anim_chars[3] = {'.', 'o', 'O'};
 #endif
 
@@ -235,7 +235,7 @@ void do_setup() {
   os.options_setup();  // Setup options
 
   pd.init();            // ProgramData init
-  #if defined(RPI-BBB-LCD)
+  #if defined(RPIBBBLCD)
     os.lcd_print_time(0);  // display time to LCD
   #endif
   if (os.start_network()) {  // initialize network
@@ -298,7 +298,7 @@ void do_loop()
 #if defined(ARDUINO)
     if (!ui_state)
       os.lcd_print_time(0);       // print time
-#elif defined(RPI-BBB-LCD)
+#elif defined(RPIBBBLCD)
     os.lcd_print_time(0);  // display time to LCD without UI state check
 #endif
 
@@ -505,7 +505,7 @@ void do_loop()
     // process LCD display
     if (!ui_state)
       os.lcd_print_station(1, ui_anim_chars[curr_time%3]);
-#elif defined(RPI-BBB-LCD)
+#elif defined(RPIBBBLCD)
     os.lcd_print_station(1, ui_anim_chars[curr_time%3]);  // LCD display without UI state check
 #endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -62,10 +62,13 @@ BufferFiller bfill;                       // buffer filler
 OpenSprinkler os; // OpenSprinkler object
 ProgramData pd;   // ProgramdData object
 
-#if defined(ARDUINO)
-
 // ====== UI defines ======
+
+#if defined(ARDUINO) || (RPI-BBB-LCD)
 static char ui_anim_chars[3] = {'.', 'o', 'O'};
+#endif
+
+#if defined(ARDUINO)
 
 #define UI_STATE_DEFAULT   0
 #define UI_STATE_DISP_IP   1
@@ -225,12 +228,16 @@ ISR(WDT_vect)
     sysReset();
   }
 }
+
 #else
 void do_setup() {
   os.begin();          // OpenSprinkler init
   os.options_setup();  // Setup options
 
   pd.init();            // ProgramData init
+  #if defined(RPI-BBB-LCD)
+    os.lcd_print_time(0);  // display time to LCD
+  #endif
   if (os.start_network()) {  // initialize network
     DEBUG_PRINTLN("network established.");
     os.status.network_fails = 0;
@@ -291,6 +298,8 @@ void do_loop()
 #if defined(ARDUINO)
     if (!ui_state)
       os.lcd_print_time(0);       // print time
+#elif defined(RPI-BBB-LCD)
+    os.lcd_print_time(0);  // display time to LCD without UI state check
 #endif
 
     // ====== Check raindelay status ======
@@ -496,6 +505,8 @@ void do_loop()
     // process LCD display
     if (!ui_state)
       os.lcd_print_station(1, ui_anim_chars[curr_time%3]);
+#elif defined(RPI-BBB-LCD)
+    os.lcd_print_station(1, ui_anim_chars[curr_time%3]);  // LCD display without UI state check
 #endif
 
     // check network connection


### PR DESCRIPTION
Hello Ray, Samer et al;

I found a port of the Arduino LiquidCrystal_I2C library for the CubieBoard, and thought it would simplify the process of making the Arduino OpenSprinkler LCD display code cross-compatible with the RPi/BBB.

So I forked it (https://github.com/denisfrench/LiquidCrystal_I2C_RPi) and tinkered a bit to make sure it worked on the RPi, which it did without any modification. I have since changed a couple of #defines that were conflicting with OpenSprinklerGen2.

I'm deliberately using an LCD backpack compatible with Martin Phirt's circuit (http://www.pihrt.com/elektronika/258-moje-rapsberry-pi-i2c-lcd-16x2), as this seems the defacto standard for OSPi/OSPy.

I've done my best to separate out the LCD code from the Arduino push-button UI code using compile-time #defines. I have not tested on Arduino, but it still appears to work fine on OSPi with the standard -DOSPI switch.

Compiling with the -DRPIBBBLCD switch reveals an incompatibility between this library and the original Arduino LiquidCrystal library in that it doesn't seem to like it when you set the base of the value to be printed to the LCD.

The internal workings of the library are still several levels beyond where my learning is at presently, so any input would be greatly appreciated.

There are also outstanding differences between the Arduino and C implementation of their Time libraries which should not be too difficult to solve, but I have not looked into as yet.

Thanks for all your efforts on this so far. I have no idea how good this is as a sprinkler system, but it sure makes a great controller for my pool pump which uses dry contacts to set the speed :-)

Best regards,
Denis.
