### PR TITLE
Switch connected to rain sensor terminals turns on/off first program

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -593,6 +593,13 @@ void check_weather() {
 }
 
 void turn_off_station(byte sid, ulong curr_time) {
+  #if defined(ENABLE_DEBUG)
+  DEBUG_PRINT("turn_off_station(");
+  DEBUG_PRINT(sid);
+  DEBUG_PRINT(", ");
+  DEBUG_PRINT(curr_time);
+  DEBUG_PRINTLN(") called");
+  #endif
   byte bid = sid>>3;
   byte s = sid&0x07;
   os.set_station_bit(sid, 0);
@@ -630,12 +637,12 @@ void turn_off_station(byte sid, ulong curr_time) {
 void process_dynamic_events(ulong curr_time) {
 #if defined(RAINPGM1) // Rain sensor triggers manual run of first program
   if (!rainpgm1act && os.options[OPTION_USE_RAINSENSOR].value && os.status.rain_sensed) {
-    manual_start_program(1);
+    manual_start_program(1); // Works, but doesn't log the station that may have been interrupted
     rainpgm1act = true;
   }
   if (rainpgm1act && os.options[OPTION_USE_RAINSENSOR].value && !os.status.rain_sensed) {
-    reset_all_stations();
-    rainpgm1act = false;
+    reset_all_stations(); // Works, but doesn't log the station that is stopped
+    rainpgm1act = false;  // also; may stop later programs if manual run already completed
   }
 #else // Normal rain sensor operation
   // check if rain is detected
@@ -731,6 +738,9 @@ void schedule_all_stations(ulong curr_time) {
 }
 
 void reset_all_stations_immediate() {
+  #if defined(ENABLE_DEBUG)
+  DEBUG_PRINTLN("reset_all_stations_immediate() called");
+  #endif
   os.clear_all_station_bits();
   os.apply_all_station_bits();
   pd.reset_runtime();
@@ -738,6 +748,9 @@ void reset_all_stations_immediate() {
 
 void reset_all_stations() {
   // stop all running and scheduled stations
+  #if defined(ENABLE_DEBUG)
+  DEBUG_PRINTLN("reset_all_stations() called");
+  #endif
   ulong curr_time = os.now_tz();
   for(byte sid=0;sid<os.nstations;sid++) {
     if(pd.scheduled_program_index[sid] > 0) {
@@ -752,6 +765,11 @@ void reset_all_stations() {
 // If pid==255, this is a short test program (2 second per station)
 // If pid > 0. run program pid-1
 void manual_start_program(byte pid) {
+  #if defined(ENABLE_DEBUG)
+  DEBUG_PRINT("manual_start_program(");
+  DEBUG_PRINT(pid);
+  DEBUG_PRINTLN(") called");
+  #endif
   boolean match_found = false;
   reset_all_stations_immediate();
   ProgramStruct prog;

--- a/main.cpp
+++ b/main.cpp
@@ -634,7 +634,7 @@ void process_dynamic_events(ulong curr_time) {
     rainpgm1act = true;
   }
   if (rainpgm1act && os.options[OPTION_USE_RAINSENSOR].value && !os.status.rain_sensed) {
-    void reset_all_stations();
+    reset_all_stations();
     rainpgm1act = false;
   }
 #else // Normal rain sensor operation

--- a/main.cpp
+++ b/main.cpp
@@ -623,6 +623,11 @@ void turn_off_station(byte sid, ulong curr_time) {
 }
 
 void process_dynamic_events(ulong curr_time) {
+#if defined(RAINPGM1) // Rain sensor triggers manual run of first program
+  if (os.options[OPTION_USE_RAINSENSOR].value && os.status.rain_sensed) {
+    manual_start_program(1);
+  }
+#else // Normal rain sensor operation
   // check if rain is detected
   bool rain = false;
   bool en = os.status.enabled ? true : false;
@@ -655,6 +660,7 @@ void process_dynamic_events(ulong curr_time) {
       }
     }
   }
+#endif
 }
 
 void schedule_all_stations(ulong curr_time) {

--- a/main.cpp
+++ b/main.cpp
@@ -44,6 +44,9 @@ char ether_buffer[ETHER_BUFFER_SIZE];
 EthernetServer *m_server = 0;
 EthernetClient *m_client = 0;
 #endif
+#if defined(RAINPGM1)
+void manual_start_program(byte pid);
+#endif
 
 // Some perturbations have been added to the timing values below
 // to avoid two events happening too clost to each other

--- a/main.cpp
+++ b/main.cpp
@@ -47,7 +47,6 @@ EthernetClient *m_client = 0;
 #if defined(RAINPGM1)
 void manual_start_program(byte pid);
 void reset_all_stations();
-bool rainpgm1act = false;
 #endif
 
 // Some perturbations have been added to the timing values below
@@ -362,9 +361,16 @@ void do_loop()
       if (os.status.rain_sensed) {
         // rain sensor on, record time
         os.rainsense_start_time = curr_time;
+        #if defined(RAINPGM1) // Rain sensor triggers manual run of first program
+        // reset_all_stations(); // Ensure any interrupted stations are logged; fail!
+        manual_start_program(1); // Replace this with method that doesn't interrupt logging!
+        #endif
       } else {
         // rain sensor off, write log
         write_log(LOGDATA_RAINSENSE, curr_time);
+        #if defined(RAINPGM1) // Rain sensor off calls manual stop
+        reset_all_stations(); // Will stop other programs if manual run already stopped!
+        #endif
       }
       os.old_status.rain_sensed = os.status.rain_sensed;
     }
@@ -593,13 +599,11 @@ void check_weather() {
 }
 
 void turn_off_station(byte sid, ulong curr_time) {
-  #if defined(ENABLE_DEBUG)
   DEBUG_PRINT("turn_off_station(");
   DEBUG_PRINT(sid);
   DEBUG_PRINT(", ");
   DEBUG_PRINT(curr_time);
   DEBUG_PRINTLN(") called");
-  #endif
   byte bid = sid>>3;
   byte s = sid&0x07;
   os.set_station_bit(sid, 0);
@@ -635,16 +639,7 @@ void turn_off_station(byte sid, ulong curr_time) {
 }
 
 void process_dynamic_events(ulong curr_time) {
-#if defined(RAINPGM1) // Rain sensor triggers manual run of first program
-  if (!rainpgm1act && os.options[OPTION_USE_RAINSENSOR].value && os.status.rain_sensed) {
-    manual_start_program(1); // Works, but doesn't log the station that may have been interrupted
-    rainpgm1act = true;
-  }
-  if (rainpgm1act && os.options[OPTION_USE_RAINSENSOR].value && !os.status.rain_sensed) {
-    reset_all_stations(); // Works, but doesn't log the station that is stopped
-    rainpgm1act = false;  // also; may stop later programs if manual run already completed
-  }
-#else // Normal rain sensor operation
+#if !defined(RAINPGM1) // Normal rain sensor operation
   // check if rain is detected
   bool rain = false;
   bool en = os.status.enabled ? true : false;
@@ -738,9 +733,7 @@ void schedule_all_stations(ulong curr_time) {
 }
 
 void reset_all_stations_immediate() {
-  #if defined(ENABLE_DEBUG)
   DEBUG_PRINTLN("reset_all_stations_immediate() called");
-  #endif
   os.clear_all_station_bits();
   os.apply_all_station_bits();
   pd.reset_runtime();
@@ -748,9 +741,7 @@ void reset_all_stations_immediate() {
 
 void reset_all_stations() {
   // stop all running and scheduled stations
-  #if defined(ENABLE_DEBUG)
   DEBUG_PRINTLN("reset_all_stations() called");
-  #endif
   ulong curr_time = os.now_tz();
   for(byte sid=0;sid<os.nstations;sid++) {
     if(pd.scheduled_program_index[sid] > 0) {
@@ -765,11 +756,9 @@ void reset_all_stations() {
 // If pid==255, this is a short test program (2 second per station)
 // If pid > 0. run program pid-1
 void manual_start_program(byte pid) {
-  #if defined(ENABLE_DEBUG)
   DEBUG_PRINT("manual_start_program(");
   DEBUG_PRINT(pid);
   DEBUG_PRINTLN(") called");
-  #endif
   boolean match_found = false;
   reset_all_stations_immediate();
   ProgramStruct prog;

--- a/main.cpp
+++ b/main.cpp
@@ -46,6 +46,8 @@ EthernetClient *m_client = 0;
 #endif
 #if defined(RAINPGM1)
 void manual_start_program(byte pid);
+void reset_all_stations();
+bool rainpgm1act = false;
 #endif
 
 // Some perturbations have been added to the timing values below
@@ -627,8 +629,13 @@ void turn_off_station(byte sid, ulong curr_time) {
 
 void process_dynamic_events(ulong curr_time) {
 #if defined(RAINPGM1) // Rain sensor triggers manual run of first program
-  if (os.options[OPTION_USE_RAINSENSOR].value && os.status.rain_sensed) {
+  if (!rainpgm1act && os.options[OPTION_USE_RAINSENSOR].value && os.status.rain_sensed) {
     manual_start_program(1);
+    rainpgm1act = true;
+  }
+  if (rainpgm1act && os.options[OPTION_USE_RAINSENSOR].value && !os.status.rain_sensed) {
+    void reset_all_stations();
+    rainpgm1act = false;
   }
 #else // Normal rain sensor operation
   // check if rain is detected


### PR DESCRIPTION
I thought this might be useful to someone else out there.

I've connected a simple switch on a length of bell wire to the rain sensor terminals to enable manual running of the first program by remote.

The functionality is enabled with the -DRAINPGM1 compile switch.

The compile switch also disables normal rain sensor operation. This could probably be done more elegantly through the UI, but this method is fine for my purpose.

Best regards,
Denis.