### PR TITLE
Add GPIO Station support

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -882,6 +882,9 @@ void OpenSprinkler::switch_special_station(byte sid, byte value) {
     } else if(stn->type==STN_TYPE_REMOTE) {
       // request remote station
       switch_remotestation(stn->data, value);
+    } else if(stn->type==STN_TYPE_GPIO) {
+      // set GPIO pin
+      switch_gpiostation(stn->data, value);
     }
   }
 }
@@ -980,6 +983,22 @@ void OpenSprinkler::switch_rfstation(byte *code, bool turnon) {
   rf_gpio_fd = -1;
 #endif
 
+}
+
+/** Switch GPIO station
+ * Special data for GPIO Station is three bytes of ascii decimal (not hex)
+ * First two bytes are zero padded GPIO pin number.
+ * Third byte is either 0 or 1 for active low (GND) or high (+5V) relays
+ */
+void OpenSprinkler::switch_gpiostation(byte *code, bool turnon) {
+  byte gpio = (*code - '0') * 10 + *(code+1) - '0';
+  byte activeState = *(code+2) - '0';
+
+  pinMode(gpio, OUTPUT);
+  if (turnon)
+    digitalWrite(gpio, activeState);
+  else
+    digitalWrite(gpio, 1-activeState);
 }
 
 /** Callback function for remote station calls */

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -134,6 +134,7 @@ public:
   static uint16_t parse_rfstation_code(byte *code, ulong *on, ulong *off); // parse rf code into on/off/time sections
   static void switch_rfstation(byte *code, bool turnon);  // switch rf station
   static void switch_remotestation(byte *code, bool turnon); // switch remote station
+  static void switch_gpiostation(byte *code, bool turnon); // switch gpio station
   static void station_attrib_bits_save(int addr, byte bits[]); // save station attribute bits to nvm
   static void station_attrib_bits_load(int addr, byte bits[]); // load station attribute bits from nvm
   static byte station_attrib_bits_read(int addr); // read one station attribte byte from nvm

--- a/defines.h
+++ b/defines.h
@@ -53,6 +53,7 @@
 #define STN_TYPE_STANDARD    0x00
 #define STN_TYPE_RF          0x01
 #define STN_TYPE_REMOTE      0x02
+#define STN_TYPE_GPIO        0x03	// Support for raw connection of station to GPIO pin
 #define STN_TYPE_OTHER       0xFF
 
 /** Sensor type macro defines */

--- a/defines.h
+++ b/defines.h
@@ -317,6 +317,8 @@ typedef enum {
   #define PIN_BUTTON_2      24    // button 2
   #define PIN_BUTTON_3      25    // button 3
 
+  #define PIN_FREE_LIST		{5,6,7,8,9,10,11,12,13,16,18,19,20,21,23,24,25,26}
+  
   /** BBB pin defines */
   #elif defined(OSBO)
 

--- a/server.cpp
+++ b/server.cpp
@@ -489,6 +489,23 @@ byte server_change_stations(char *p)
       int stepsize=sizeof(StationSpecialData);
       tmp_buffer[0]-='0';
       tmp_buffer[stepsize-1] = 0;
+
+	  if(tmp_buffer[0] == STN_TYPE_GPIO) {
+#if defined(OSPI) // check that pin does not clash with OSPi pins
+		  byte gpio = (tmp_buffer[1] - '0') * 10 + tmp_buffer[2] - '0';
+		  byte activeState = tmp_buffer[3] - '0';
+
+		  byte gpioList[] = PIN_FREE_LIST;
+		  bool found = false;
+		  for (int i = 0; i < sizeof(gpioList) && found == false; i++) {
+			  if (gpioList[i] == gpio) found = true;
+		  }
+		  if (!found || activeState > 1) return HTML_DATA_OUTOFBOUND;
+#else	 // only allow GPIO stations if OSPi
+		  return HTML_NOT_PERMITTED;
+#endif
+	  }
+
       write_to_file(stns_filename, tmp_buffer, strlen(tmp_buffer)+1, stepsize*sid, false);
     } else {
       return HTML_DATA_MISSING;


### PR DESCRIPTION
I modified the Special Station functionality that supports RF and IP stations to also control a raw GPIO pin. In essence this allows you to bypass the shift register/triac/protection circuitry of the OSPi and directly control a spare RPi gpio pin and any connected homebrew relay hardware. The /cs api command allows the setting of GPIO station type, gpio pin and active low/high.

I have a pull request for OS-App as well that provides the UI (see attached)  to associate any gpio pin with a station and set whether the hardware is active high or low.

Two areas that need some consideration:
1) GPIO Pin Contention - There in no validation of gpio usage in the Firmware but the UI restricts selection to avoid OSPi dedicated pins (i.e. shift register, RF, etc).
2) RPi R2 Only - The App assumes an OSPi with R2 connector. I couldnt see a way to detect if Arduino or RPi R1 to provide a tailored gpio selector.

Appreciate any feedback

![gpio stations](https://cloud.githubusercontent.com/assets/16738570/12377022/9cfc95ae-bd05-11e5-846c-e1ee02638d80.jpg)
