### PR TITLE
Added ability to set reference weather conditions (Temp, Rain, Humidty) to the Zimmerman adjustment method

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -25,11 +25,11 @@
 #define _DEFINES_H
 
 /** Firmware version, hardware version, and maximal values */
-#define OS_FW_VERSION  217  // Firmware version: 217 means 2.1.7
+#define OS_FW_VERSION  216  // Firmware version: 216 means 2.1.6
                             // if this number is different from the one stored in non-volatile memory
                             // a device reset will be automatically triggered
 
-#define OS_FW_MINOR      1  // Firmware minor version
+#define OS_FW_MINOR      2  // Firmware minor version
 
 /** Hardware version base numbers */
 #define OS_HW_VERSION_BASE   0x00

--- a/defines.h
+++ b/defines.h
@@ -25,7 +25,7 @@
 #define _DEFINES_H
 
 /** Firmware version, hardware version, and maximal values */
-#define OS_FW_VERSION  216  // Firmware version: 216 means 2.1.6
+#define OS_FW_VERSION  217  // Firmware version: 217 means 2.1.7
                             // if this number is different from the one stored in non-volatile memory
                             // a device reset will be automatically triggered
 

--- a/weather.cpp
+++ b/weather.cpp
@@ -120,8 +120,8 @@ void GetWeather() {
   ether.dnsLookup(tmp_buffer, true);
 
   //bfill=ether.tcpOffset();
-  char tmp[30];
-  read_from_file(wtopts_filename, tmp, 30);
+  char tmp[60];
+  read_from_file(wtopts_filename, tmp, 60);
   BufferFiller bf = (uint8_t*)tmp_buffer;
   bf.emit_p(PSTR("$D.py?loc=$E&key=$E&fwv=$D&wto=$S"),
                 (int) os.options[OPTION_USE_WEATHER],


### PR DESCRIPTION
Samer/Ray,

I have done three pull requests (one on Firmware, one on App and one on Weather) to add the ability to adjust the baseline weather conditions in the Zimmerman adjustment method. See forum thread [https://opensprinkler.com/forums/topic/zimmerman-parameters/](url)

- App - main.js, I have extended the showZimmermanAdjustmentOptions function to include three additional input fields to capture the reference temperature, humidity and daily rainfall. In addition, I have used weather.forecast.region to determine the locale and from that whether to display in metric or imperial. I am uncertain if that object is always defined and would like confirmation that it is therefore available for use. It is set when wunderground is enabled and is referenceable in Zimmerman function but perhaps there are conditions when this is not so. The function converts to/from imperial when communicating with Firmware. 

- Weather – server.js: I have modified server.js to take the three reference parameters but to use default values of Temp = 70F, Humidity = 30% and Daily Rain = 0in if these references are not passed. This provides backwards compatibility with previous versions.

- Firmware – wtopts.txt: although wto options are largely transparent to Firmware, this change extends the wtopts.txt file with three new options (bh, br, bt) for the baseline weather conditions: bh is a percentage humidity; br is daily rainfall in inches to three decimals; and bt is degrees fahrenheiht to two decimal places. The precision is so we can convert to metric in the UI while still retaining tenths of degrees celsius and mm. This results in an increase to the size of wtopts.txt to a maximum of 55 bytes.

- Firmware – weather.cpp: I see in weather.cpp that a char tmp[100] buffer is used to store wtopts.txt on OSPi which looks fine. However, a char tmp[30] is used on Arduino. I am unsure how much memory headroom is available under Arduino and whether the array can be extended to 60 bytes. Do you see this as a problem as I could look a bit harder to reduce the memory increase?

Thanks, Peter
