### PR TITLE
Added support for HTTP Stations

### DIFF
--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -57,12 +57,26 @@ struct StationSpecialData {
   byte data[STATION_SPECIAL_DATA_SIZE];
 };
 
-/** Remote station data structure */
-// this must fit in STATION_SPECIAL_DATA_SIZE
+/** Station data structures - Must fit in STATION_SPECIAL_DATA_SIZE */
+struct RFStationData {
+  byte on[6];
+  byte off[6];
+  byte timing[4];
+};
+
 struct RemoteStationData {
-  byte ip[4];
-  uint16_t port;
-  byte sid;
+  byte ip[8];
+  byte port[4];
+  byte sid[2];
+};
+
+struct GPIOStationData {
+  byte pin[2];
+  byte active;
+};
+
+struct HTTPStationData {
+  byte data[STATION_SPECIAL_DATA_SIZE];
 };
 
 /** Volatile controller status bits */
@@ -131,10 +145,11 @@ public:
   // -- station names and attributes
   static void get_station_name(byte sid, char buf[]); // get station name
   static void set_station_name(byte sid, char buf[]); // set station name
-  static uint16_t parse_rfstation_code(byte *code, ulong *on, ulong *off); // parse rf code into on/off/time sections
-  static void switch_rfstation(byte *code, bool turnon);  // switch rf station
-  static void switch_remotestation(byte *code, bool turnon); // switch remote station
-  static void switch_gpiostation(byte *code, bool turnon); // switch gpio station
+  static uint16_t parse_rfstation_code(RFStationData *data, ulong *on, ulong *off); // parse rf code into on/off/time sections
+  static void switch_rfstation(RFStationData *data, bool turnon);  // switch rf station
+  static void switch_remotestation(RemoteStationData *data, bool turnon); // switch remote station
+  static void switch_gpiostation(GPIOStationData *data, bool turnon); // switch gpio station
+  static void switch_httpstation(HTTPStationData *data, bool turnon); // switch http station
   static void station_attrib_bits_save(int addr, byte bits[]); // save station attribute bits to nvm
   static void station_attrib_bits_load(int addr, byte bits[]); // load station attribute bits from nvm
   static byte station_attrib_bits_read(int addr); // read one station attribte byte from nvm

--- a/defines.h
+++ b/defines.h
@@ -24,6 +24,8 @@
 #ifndef _DEFINES_H
 #define _DEFINES_H
 
+#define TMP_BUFFER_SIZE      128    // scratch buffer size
+
 /** Firmware version, hardware version, and maximal values */
 #define OS_FW_VERSION  216  // Firmware version: 216 means 2.1.6
                             // if this number is different from the one stored in non-volatile memory
@@ -45,7 +47,7 @@
 /** File names */
 #define WEATHER_OPTS_FILENAME "wtopts.txt"    // weather options file
 #define STATION_ATTR_FILENAME "stns.dat"      // station attributes data file
-#define STATION_SPECIAL_DATA_SIZE  23
+#define STATION_SPECIAL_DATA_SIZE  (TMP_BUFFER_SIZE - 8)
 
 #define FLOWCOUNT_RT_WINDOW   30    // flow count window (for computing real-time flow rate), 30 seconds
 
@@ -54,6 +56,7 @@
 #define STN_TYPE_RF          0x01
 #define STN_TYPE_REMOTE      0x02
 #define STN_TYPE_GPIO        0x03	// Support for raw connection of station to GPIO pin
+#define STN_TYPE_HTTP        0x04	// Support for HTTP Get connection
 #define STN_TYPE_OTHER       0xFF
 
 /** Sensor type macro defines */
@@ -383,8 +386,6 @@ typedef enum {
   typedef bool boolean;
 
 #endif  // end of Hardawre defines
-
-#define TMP_BUFFER_SIZE     128  // scratch buffer size
 
 /** Other defines */
 // button values

--- a/server.cpp
+++ b/server.cpp
@@ -485,7 +485,7 @@ byte server_change_stations(char *p)
     sid = atoi(tmp_buffer);
     if(sid<0 || sid>os.nstations) return HTML_DATA_OUTOFBOUND;
     if(findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("st"), true) &&
-       findKeyVal(p, tmp_buffer+1, TMP_BUFFER_SIZE, PSTR("sd"), true)) {
+       findKeyVal(p, tmp_buffer+1, TMP_BUFFER_SIZE-1, PSTR("sd"), true)) {
       int stepsize=sizeof(StationSpecialData);
       tmp_buffer[0]-='0';
       tmp_buffer[stepsize-1] = 0;
@@ -504,6 +504,11 @@ byte server_change_stations(char *p)
 #else	 // only allow GPIO stations if OSPi
 		  return HTML_NOT_PERMITTED;
 #endif
+	  } else if (tmp_buffer[0] == STN_TYPE_HTTP) {
+		  urlDecode(tmp_buffer + 1); // Unwind any url encoding of special data
+		  if (strlen(tmp_buffer+1) > sizeof(HTTPStationData)) {
+			  return HTML_DATA_OUTOFBOUND;
+		  }
 	  }
 
       write_to_file(stns_filename, tmp_buffer, strlen(tmp_buffer)+1, stepsize*sid, false);


### PR DESCRIPTION
There are changes across both Firmware and App to support this feature.

The HTTP Station is a simple extension of the existing handler routines in both App and Firmware. This is very similar to the Remote Station code and allows the user to send HTTP GET commands to a server by configuring the following settings { Server, Port, On command, Off command }.

I have used a simple comma separated string to hold the above four parameters when transferring special data between App and Firmware using the api calls. This is a little different to the other Special Stations that use fixed width parameters. I did this because I wanted to support server names, in addition to IP addresses, and the On/Off commands can be arbitrary length.

In Firmware, I have extended the SpecialStationData structure from 23 to 120 bytes, i.e. the scratch buffer size, so that we can store complex On/Off commands (e.g. with hashed passwords or user tokens). This results in stns.dat file around four times the original size but still only ~4k so hoping that this is acceptable.

In the App, the number of Special Station Types is getting quite significant and the parameters were resulting in a really tall Station Attribute dialogue box. So I have introduced a “tabbed” version of the dialogue with Basic/Advanced pages. This keeps things a little more tidy.

Given the change to the stns.dat file format, this feature should really come in on a major version upgrade as it will require the user to do an export/import of settings to avoid stns.dat file corruption.

There are some things that I thought might be worth adding if you think useful:

- Specify whether a GET or POST message is used
- Select between “send and refresh” or “single shot” approach to keeping HTTP Station is sync
- Strip out any initial “/” entered by the user for the On or Off command entered into the App