### PR TITLE
Update utils.cpp

### DIFF
--- a/utils.cpp
+++ b/utils.cpp
@@ -90,10 +90,10 @@ void nvm_read_block(void *dst, const void *src, int len) {
 void nvm_write_block(const void *src, void *dst, int len) {
   FILE *fp = fopen(get_filename_fullpath(NVM_FILENAME), "rb+");
   if(!fp) {
-    fp = fopen(get_filename_fullpath(NVM_FILENAME), "wb");
+    fp = fopen(get_filename_fullpath(NVM_FILENAME), "wb+"); //This will open the file for editting after creation
   }
   if(fp) {
-    fseek(fp, (unsigned int)dst, SEEK_SET);
+    fseek(fp, (unsigned int)dst, SEEK_SET); //this fails silently without the above change
     fwrite(src, 1, len, fp);
     fclose(fp);
   } else {
@@ -117,10 +117,10 @@ byte nvm_read_byte(const byte *p) {
 void nvm_write_byte(const byte *p, byte v) {
   FILE *fp = fopen(get_filename_fullpath(NVM_FILENAME), "rb+");
   if(!fp) {
-    fp = fopen(get_filename_fullpath(NVM_FILENAME), "wb");
+    fp = fopen(get_filename_fullpath(NVM_FILENAME), "wb+"); //This will open the file for editting after creation
   }
   if(fp) {
-    fseek(fp, (unsigned int)p, SEEK_SET);
+    fseek(fp, (unsigned int)p, SEEK_SET); //This fails silently without above change
     fwrite(&v, 1, 1, fp);
     fclose(fp);
   } else {


### PR DESCRIPTION
The wb+ setting needs to be used otherwise the nvm.dat file will be created but not opened for editing on the RPi devices.  The lack of an error check in the function allows the silent failure to cause an issue where the file is not updated properly and fails silently.