### PR TITLE
Updating the README links

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,10 +5,10 @@
 This is a unified OpenSprinkler firmware for Arduino, and Linux-based OpenSprinklers such as OpenSprinkler Pi.
 
 For OS (Arduino-based OpenSprinkler) 2.x:
-https://opensprinkler.freshdesk.com/solution/articles/5000165132-how-to-compile-opensprinkler-firmware
+https://openthings.freshdesk.com/support/solutions/articles/5000165132-how-to-compile-opensprinkler-firmware
 
 For OSPi/OSBO or other Linux-based OpenSprinkler:
-https://opensprinkler.freshdesk.com/support/solutions/articles/5000631599-installing-and-updating-the-unified-firmware
+https://openthings.freshdesk.com/support/solutions/articles/5000631599-installing-and-updating-the-unified-firmware
 
 ============================================
 Questions and comments:


### PR DESCRIPTION
The Readme links are still pointing to opensprinkler.freshdesk.com instead of openthings.