### PR TITLE
Fix buffer overrun when storing long http station configuration

### DIFF
--- a/server.cpp
+++ b/server.cpp
@@ -166,7 +166,12 @@ byte findKeyVal (const char *str,char *strbuf, uint8_t maxlen,const char *key,bo
       str++;
       strbuf++;
     }
-    *strbuf='\0';
+    if (!(*str) || *str == ' ' || *str == '\n' || *str == '&') {
+      *strbuf = '\0';
+    } else {
+      found = 0;  // Ignore partial values i.e. value length is larger than maxlen
+      i = 0;
+    }
   }
   // return the length of the value
   if (keyfound) *keyfound = found;
@@ -238,7 +243,12 @@ byte findKeyVal (const char *str,char *strbuf, uint8_t maxlen,const char *key,bo
       str++;
       strbuf++;
     }
-    *strbuf='\0';
+    if (!(*str) ||  *str == ' ' || *str == '\n' || *str == '&') {
+      *strbuf = '\0';
+    } else {
+      found = 0;  // Ignore partial values i.e. value length is larger than maxlen
+      i = 0;
+    }
   }
   // return the length of the value
   if (keyfound) *keyfound = found;


### PR DESCRIPTION
Hey Ray

Companion to PR40 submitted to OS App.
Just a suggestion but an option to adjust logic of findKeyVal() if useful.

Cheers, Pete
------------------------------------------
PR: Firmware - Current findKeyVal logic will truncate a Value string if longer than tmp_buffer's 255 bytes. This could result in corrupt config passing into the system. Although this situation should never arise, the bug in my HTTP Station code did trigger this scenario. An alternative logic, provided in the PR, rejects any key/value pair that cannot be contained in the receiving buffer. An alternative approach would be to change the return value to "signed" and signal a truncation error (-1).

Let me know if any thoughts/changes required and happy to rework as needed.
Cheers, Pete