### PR TITLE
Feature Notifier - Extending integration options and flow related notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ nvm.dat
 OpenSprinkler
 wtopts.txt
 stns.dat
+ifttt.txt
+ifkey.txt
+name.txt
+webhook.txt
+influx.txt

--- a/EtherCard.h
+++ b/EtherCard.h
@@ -334,6 +334,10 @@ public:
                           const char *additionalheaderline, const char *postval,
                           void (*callback)(uint8_t,uint16_t,uint16_t));
 
+    static void httpPostRam (const char *urlbuf, const char *hoststr,
+                          const char *additionalheaderline, const char *postval,
+                          void (*callback)(uint8_t,uint16_t,uint16_t));
+
     static void httpPostVar (const char *urlbuf, const char *hoststr,
                           const char *urlbuf_varpart, const char *postval,
                           void (*callback)(uint8_t,uint16_t,uint16_t));
@@ -474,11 +478,12 @@ public:
     /**   @brief  Perform DNS lookup
     *     @param  name Host name to lookup
     *     @param  fromRam Set true to look up cached name. Default = false
+    *     @param  timeout Maximum time to wait for response
     *     @return <i>bool</i> True on success.
     *     @note   Result is stored in <i>hisip</i> member
     */
-    static bool dnsLookup (const char* name, bool fromRam =false);
 
+    static bool dnsLookup(const char* name, bool fromRam = false, uint32_t timeout = 30000);
     // webutil.cpp
     /**   @brief  Copies an IP address
     *     @param  dst Pointer to the 4 byte destination

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -61,7 +61,7 @@ const char ifkey_filename[]   PROGMEM = IFTTT_KEY_FILENAME;
 const char ifttt_filename[]   PROGMEM = IFTTT_FILENAME;
 const char webhook_filename[] PROGMEM = WEBHOOK_FILENAME;
 const char influx_filename[]  PROGMEM = INFLUX_FILENAME;
-const char name_filename[]    PROGMEM = NAME_FILENAME;
+const char site_filename[]    PROGMEM = SITE_FILENAME;
 #ifdef ESP8266
 const char wifi_filename[]   PROGMEM = WIFI_FILENAME;
 byte OpenSprinkler::state = OS_STATE_INITIAL;
@@ -1532,7 +1532,7 @@ void OpenSprinkler::options_setup() {
 #ifndef ESP8266
     // 5. delete sd file
     remove_file(wtopts_filename);
-    remove_file(name_filename);
+    remove_file(site_filename);
     remove_file(ifkey_filename);
     remove_file(ifttt_filename);
     remove_file(influx_filename);

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -55,9 +55,13 @@ byte OpenSprinkler::weather_update_flag;
 
 char tmp_buffer[TMP_BUFFER_SIZE+1];       // scratch buffer
 
-const char wtopts_filename[] PROGMEM = WEATHER_OPTS_FILENAME;
-const char stns_filename[]   PROGMEM = STATION_ATTR_FILENAME;
-const char ifkey_filename[]  PROGMEM = IFTTT_KEY_FILENAME;
+const char wtopts_filename[]  PROGMEM = WEATHER_OPTS_FILENAME;
+const char stns_filename[]    PROGMEM = STATION_ATTR_FILENAME;
+const char ifkey_filename[]   PROGMEM = IFTTT_KEY_FILENAME;
+const char ifttt_filename[]   PROGMEM = IFTTT_FILENAME;
+const char webhook_filename[] PROGMEM = WEBHOOK_FILENAME;
+const char influx_filename[]  PROGMEM = INFLUX_FILENAME;
+const char name_filename[]    PROGMEM = NAME_FILENAME;
 #ifdef ESP8266
 const char wifi_filename[]   PROGMEM = WIFI_FILENAME;
 byte OpenSprinkler::state = OS_STATE_INITIAL;
@@ -1528,7 +1532,11 @@ void OpenSprinkler::options_setup() {
 #ifndef ESP8266
     // 5. delete sd file
     remove_file(wtopts_filename);
+    remove_file(name_filename);
     remove_file(ifkey_filename);
+    remove_file(ifttt_filename);
+    remove_file(influx_filename);
+    remove_file(webhook_filename);
 #endif
 
     // 6. write options

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -110,7 +110,7 @@ extern const char ifkey_filename[];
 extern const char ifttt_filename[];
 extern const char influx_filename[];
 extern const char webhook_filename[];
-extern const char name_filename[];
+extern const char site_filename[];
 extern const char op_max[];
 extern const char op_json_names[];
 #ifdef ESP8266

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -107,6 +107,10 @@ struct ConStatus {
 extern const char wtopts_filename[];
 extern const char stns_filename[];
 extern const char ifkey_filename[];
+extern const char ifttt_filename[];
+extern const char influx_filename[];
+extern const char webhook_filename[];
+extern const char name_filename[];
 extern const char op_max[];
 extern const char op_json_names[];
 #ifdef ESP8266

--- a/build.sh
+++ b/build.sh
@@ -11,11 +11,11 @@ done
 echo "Building OpenSprinkler..."
 
 if [ "$1" == "demo" ]; then
-	g++ -o OpenSprinkler -DDEMO -m32 main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp -lpthread
+	g++ -o OpenSprinkler -DDEMO -m32 main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp notifier.cpp gpio.cpp etherport.cpp -lpthread
 elif [ "$1" == "osbo" ]; then
-	g++ -o OpenSprinkler -DOSBO main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp -lpthread
+	g++ -o OpenSprinkler -DOSBO main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp notifier.cpp gpio.cpp etherport.cpp -lpthread
 else
-	g++ -o OpenSprinkler -DOSPI main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp -lpthread
+	g++ -o OpenSprinkler -DOSPI main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp notifier.cpp gpio.cpp etherport.cpp -lpthread
 fi
 
 if [ ! "$SILENT" = true ] && [ -f OpenSprinkler.launch ] && [ ! -f /etc/init.d/OpenSprinkler.sh ]; then

--- a/defines.h
+++ b/defines.h
@@ -35,7 +35,7 @@
                             // if this number is different from the one stored in non-volatile memory
                             // a device reset will be automatically triggered
 
-#define OS_FW_MINOR      1  // Firmware minor version
+#define OS_FW_MINOR      2  // Firmware minor version
 
 /** Hardware version base numbers */
 #define OS_HW_VERSION_BASE   0x00
@@ -56,7 +56,7 @@
 #define IFTTT_FILENAME       "ifttt.txt"   // Store IFTTT endpoint event names
 #define WEBHOOK_FILENAME     "webhook.txt" // Webhook requires server and port number
 #define INFLUX_FILENAME      "influx.txt"  // Influx requires server, port and database name
-#define NAME_FILENAME        "name.txt"    // Unique name of unit to send with notifications
+#define SITE_FILENAME        "site.txt"    // Unique name of unit to send with notifications
 #define STATION_SPECIAL_DATA_SIZE  (TMP_BUFFER_SIZE - 8)
 
 #define FLOWCOUNT_RT_WINDOW   30    // flow count window (for computing real-time flow rate), 30 seconds

--- a/defines.h
+++ b/defines.h
@@ -53,7 +53,10 @@
 #define STATION_ATTR_FILENAME "stns.dat"      // station attributes data file
 #define WIFI_FILENAME         "wifi.dat"      // wifi credentials file
 #define IFTTT_KEY_FILENAME    "ifkey.txt"
-#define IFTTT_KEY_MAXSIZE     128
+#define IFTTT_FILENAME       "ifttt.txt"   // Store IFTTT endpoint event names
+#define WEBHOOK_FILENAME     "webhook.txt" // Webhook requires server and port number
+#define INFLUX_FILENAME      "influx.txt"  // Influx requires server, port and database name
+#define NAME_FILENAME        "name.txt"    // Unique name of unit to send with notifications
 #define STATION_SPECIAL_DATA_SIZE  (TMP_BUFFER_SIZE - 8)
 
 #define FLOWCOUNT_RT_WINDOW   30    // flow count window (for computing real-time flow rate), 30 seconds
@@ -65,13 +68,6 @@
 #define STN_TYPE_GPIO        0x03	// Support for raw connection of station to GPIO pin
 #define STN_TYPE_HTTP        0x04	// Support for HTTP Get connection
 #define STN_TYPE_OTHER       0xFF
-
-#define IFTTT_PROGRAM_SCHED   0x01
-#define IFTTT_RAINSENSOR      0x02
-#define IFTTT_FLOWSENSOR      0x04
-#define IFTTT_WEATHER_UPDATE  0x08
-#define IFTTT_REBOOT          0x10
-#define IFTTT_STATION_RUN     0x20
 
 /** Sensor type macro defines */
 #define SENSOR_TYPE_NONE    0x00

--- a/dns.cpp
+++ b/dns.cpp
@@ -87,20 +87,20 @@ static bool checkForDnsAnswer (uint16_t plen) {
 }
 
 // use during setup, as this discards all incoming requests until it returns
-bool EtherCard::dnsLookup (const char* name, bool fromRam) {
+bool EtherCard::dnsLookup (const char* name, bool fromRam, uint32_t timeout) {
     word start = millis();
 
     while(!isLinkUp())
     {
         packetLoop(packetReceive());
-        if ((word) (millis() - start) >= 30000)
+        if ((word) (millis() - start) >= timeout)
             return false; //timeout waiting for link
     }
     start = millis();
     while(clientWaitingGw())
     {
         packetLoop(packetReceive());
-        if ((word) (millis() - start) >= 30000)
+        if ((word) (millis() - start) >= timeout)
             return false; //timeout waiting for gateway ARP
     }
 
@@ -109,7 +109,7 @@ bool EtherCard::dnsLookup (const char* name, bool fromRam) {
 
     start = millis();
     while (hisip[0] == 0) {
-        if ((word) (millis() - start) >= 30000)
+        if ((word) (millis() - start) >= timeout)
             return false; //timout waiting for dns response
         word len = packetReceive();
         if (len > 0 && packetLoop(len) == 0) //packet not handled by tcp/ip packet loop

--- a/etherport.cpp
+++ b/etherport.cpp
@@ -180,7 +180,6 @@ int EthernetClient::connect(uint8_t ip[4], uint16_t port, uint16_t timeout)
 	// Use Select() to determine if connection within timeout period
 	if (select(m_sock + 1, NULL, &fdset, NULL, &tv) <= 0)
 	{
-		DEBUG_PRINTLN("error connecting to server");
 		return 0;
 	}
 

--- a/etherport.cpp
+++ b/etherport.cpp
@@ -30,6 +30,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <fcntl.h> 
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
@@ -144,6 +145,45 @@ int EthernetClient::connect(uint8_t ip[4], uint16_t port)
     DEBUG_PRINTLN("error connecting to server");
     return 0;
 	}
+	m_connected = true;
+	return 1;
+}
+
+int EthernetClient::connect(uint8_t ip[4], uint16_t port, uint16_t timeout)
+{
+	struct sockaddr_in sin = { 0 };
+	struct timeval tv;
+	fd_set fdset;
+	int flags;
+
+	if (m_sock)
+		return 0;
+
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(port);
+	sin.sin_addr.s_addr = *(uint32_t*)(ip);
+
+	// Open the socket and initiate connection in non-blocking mode
+	m_sock = socket(AF_INET, SOCK_STREAM, 0);
+	flags = fcntl(m_sock, F_GETFL, 0);
+	fcntl(m_sock, F_SETFL, flags | O_NONBLOCK);
+	::connect(m_sock, (struct sockaddr *) &sin, sizeof(sin));
+
+	// Put socket back into Blocking mode to retain compatibility with read/write code
+	fcntl(m_sock, F_SETFL, flags & (~O_NONBLOCK));
+
+	FD_ZERO(&fdset);
+	FD_SET(m_sock, &fdset);
+	tv.tv_sec = timeout;
+	tv.tv_usec = 0;
+
+	// Use Select() to determine if connection within timeout period
+	if (select(m_sock + 1, NULL, &fdset, NULL, &tv) <= 0)
+	{
+		DEBUG_PRINTLN("error connecting to server");
+		return 0;
+	}
+
 	m_connected = true;
 	return 1;
 }

--- a/etherport.h
+++ b/etherport.h
@@ -46,6 +46,7 @@ public:
 	EthernetClient(int sock);
 	~EthernetClient();
 	int connect(uint8_t ip[4], uint16_t port);
+	int connect(uint8_t ip[4], uint16_t port, uint16_t timeout);
 	bool connected();
 	void stop();
 	int read(uint8_t *buf, size_t size);

--- a/main.cpp
+++ b/main.cpp
@@ -305,8 +305,10 @@ void do_setup() {
 #endif
 
   if (os.start_network()) {  // initialize network
+    DEBUG_PRINTLN("network established.");
     os.status.network_fails = 0;
   } else {
+    DEBUG_PRINTLN("network failed.");
     os.status.network_fails = 1;
   }
   os.status.req_network = 0;
@@ -329,6 +331,8 @@ ISR(WDT_vect)
   // this isr is called every 8 seconds
   if (wdt_timeout > 15) {
     // reset after 120 seconds of timeout
+    DEBUG_PRINTLN("WDT Triggered");
+    delay(2000);
     sysReset();
   }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -502,6 +502,25 @@ void do_loop()
       os.lcd_print_time(os.now_tz());       // print time
 #endif
 
+    // ====== Distribute Flow Count amonst running stations and programs ======
+    if (os.options[OPTION_SENSOR_TYPE] == SENSOR_TYPE_FLOW) {
+      static ulong last_flow_count = 0;
+      if (flow_count > last_flow_count) {
+        RuntimeQueueStruct * q = NULL;
+        int nrunning = 0;
+        for (q = pd.queue; q < pd.queue + pd.nqueue; q++) {
+          if (q->running) nrunning++;
+        }
+        for(q = pd.queue; q < pd.queue + pd.nqueue; q++) {
+          if (q->running) {
+            q->volume += (float)(flow_count - last_flow_count) / nrunning;
+            q->pgm->volume += (float)(flow_count - last_flow_count) / nrunning;
+          }
+        }
+      }
+      last_flow_count = flow_count;
+    }
+
     // ====== Check raindelay status ======
     if (os.status.rain_delayed) {
       if (curr_time >= os.nvdata.rd_stop_time) {  // rain delay is over

--- a/mainArduino.ino
+++ b/mainArduino.ino
@@ -23,6 +23,10 @@
  
 #include <OpenSprinkler.h>
 
+// Library headers to support IDE build process
+#include <Wire.h>
+#include <SDFat.h>
+
 extern OpenSprinkler os;
 
 void do_setup();

--- a/notifier.cpp
+++ b/notifier.cpp
@@ -1,0 +1,735 @@
+/* OpenSprinkler Unified (AVR/RPI/BBB/LINUX) Firmware
+* Copyright (C) 2015 by Ray Wang (ray@opensprinkler.com)
+*
+* Notification routines
+* Feb 2015 @ OpenSprinkler.com
+*
+* This file is part of the OpenSprinkler Firmware
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see
+* <http://www.gnu.org/licenses/>.
+*/
+
+#if !defined(ARDUINO) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega1284__)
+
+#include "OpenSprinkler.h"
+#include "program.h"
+#include "notifier.h"
+
+#if defined(ARDUINO)
+#include "time.h"
+#include "SdFat.h"
+extern byte Ethernet::buffer[ETHER_BUFFER_SIZE]; // Ethernet packet buffer
+extern SdFat sd;                                 // SD card object
+#else // header and defs for RPI/BBB
+#include <sys/stat.h>
+#include <netdb.h>
+#include <stdlib.h>
+#include <time.h>
+extern char ether_buffer[ETHER_BUFFER_SIZE];
+#define sprintf_P sprintf
+#define sscanf_P sscanf
+#endif
+
+#if PROGRAM_NAME_SIZE > STATION_NAME_SIZE
+#define NAME_SIZE PROGRAM_NAME_SIZE
+#else
+#define NAME_SIZE STATION_NAME_SIZE
+#endif
+#define IFTTT_KEY_MAXSIZE          128  // Max size for IFTTT key - current keys are around 50 characters
+#define IFTTT_EVENT_MAXNUM         8    // Maximum number of unique IFTTT endpoints
+#define IFTTT_EVENT_MAXSIZE        20   // Maximum characters per IFTTT event name
+#define INFLUX_SERVER_MAXSIZE      30   // Maximum length of the influx server name
+#define INFLUX_DATABASE_MAXSIZE    25   // Maximum length of the influx database name
+#define WEBHOOK_SERVER_MAXSIZE     30   // Maximum length of the WeebHook server name
+
+typedef enum {
+  NOTIF_PROGRAM_SCHEDULE,
+  NOTIF_PROGRAM_START,
+  NOTIF_PROGRAM_STOP,
+  NOTIF_STATION_SCHEDULE,
+  NOTIF_STATION_OPEN,
+  NOTIF_STATION_CLOSE,
+  NOTIF_RAINSENSOR_ON,
+  NOTIF_RAINSENSOR_OFF,
+  NOTIF_RAINDELAY_START,
+  NOTIF_RAINDELAY_STOP,
+  NOTIF_FLOW_UPDATE,
+  NOTIF_WEATHERCALL_FAIL,
+  NOTIF_WEATHERCALL_SUCCESS,
+  NOTIF_WATERLEVEL_UPDATE,
+  NOTIF_IP_UPDATE,
+  NOTIF_REBOOT_COMPLETE
+} notification_t;
+
+typedef struct {
+  byte id;              // Contains either an SID or a PID for station/program notifications
+  char name[NAME_SIZE]; // Contains either a station or program name
+  ulong start;          // Start time of a program/station run in unix epoch time in GMT
+  ulong end;            // End time of a program/station run in unix epoch time in GMT
+  ulong duration;       // Duration of the program/station run in seconds
+  byte water_level;     // Water level at the start of a program or station run
+  float volume;         // Volume of water used during the program/station run 
+  float flow;           // Average flow of water during the station/program run (or 0 if no flow meter)
+  ulong ip;             // Newly detected external IP address (4 byte coded)
+} push_msg_t;
+
+// IFTTT event mask used to communicate with App
+#define IFTTT_PROGRAM_SCHED   0x01
+#define IFTTT_RAINSENSOR      0x02
+#define IFTTT_FLOWSENSOR      0x04
+#define IFTTT_WEATHER_UPDATE  0x08
+#define IFTTT_REBOOT          0x10
+#define IFTTT_STATION_RUN     0x20
+#define IFTTT_SPARE_1         0x40
+#define IFTTT_SPARE_2         0x80
+
+// Mapping table from notification types to IFTTT types
+byte ifttt_map[] = { 
+  0,                    // NOTIF_PROGRAM_SCHEDULE
+  IFTTT_PROGRAM_SCHED,  // NOTIF_PROGRAM_START
+  0,                    // NOTIF_PROGRAM_STOP
+  0,                    // NOTIF_STATION_SCHEDULE
+  0,                    // NOTIF_STATION_OPEN
+  IFTTT_STATION_RUN,    // NOTIF_STATION_CLOSE
+  IFTTT_RAINSENSOR,     // NOTIF_RAINSENSOR_ON
+  IFTTT_RAINSENSOR,     // NOTIF_RAINSENSOR_OFF
+  0,                    // NOTIF_RAINDELAY_START
+  0,                    // NOTIF_RAINDELAY_STOP
+  IFTTT_FLOWSENSOR,     // NOTIF_FLOW_UPDATE
+  0,                    // NOTIF_WEATHERCALL_FAIL
+  0,                    // NOTIF_WEATHERCALL_SUCCESS
+  IFTTT_WEATHER_UPDATE, // NOTIF_WATERLEVEL_UPDATE
+  0,                    // NOTIF_IP_UPDATE
+  IFTTT_REBOOT          // NOTIF_REBOOT_COMPLETE
+};
+
+extern ProgramData pd;          // ProgramdData object
+extern char tmp_buffer[];       // scratch buffer
+static char post_buff[512];     // POST message - largest IFTTT message is approx 350 bytes as contains three versions of the message
+
+static void post_msg(const char * server, int port, const char * url, const char * var, const char * postval);
+static void strip_spaces(char * i);
+
+static void push_message(ulong timestamp, notification_t type, push_msg_t * msg);
+static void push_ifttt_message(ulong timestamp, notification_t type, push_msg_t * m);
+static void push_influxdb_message(ulong timestamp, notification_t type, push_msg_t * m);
+static void push_webhook_message(ulong timestamp, notification_t type, push_msg_t * m);
+
+static int format_text_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m);
+static int format_value_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m);
+static int format_json_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m);
+static int format_influx_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m);
+
+// ================================
+// NOTIFICATION FUNCTIONS
+// ================================
+void helper_populate_pgm_message(push_msg_t * m, RuntimePgmStruct * pgm) {
+  ProgramStruct prog = { 0 };
+  byte pid = pgm->pid;
+
+  if (pid == 0 || pid > pd.nprograms) {
+    m->id = (pid == 99) ? 99 : 254;
+    strcpy_P(m->name, (pid == 99) ? PSTR("Manual") : PSTR("Run-Once"));
+    m->water_level = 100;
+  }
+  else {
+    pd.read(pid - 1, &prog);
+    m->id = pid - 1;
+    strcpy(m->name, (prog.name) ? prog.name : "Unknown");
+    m->water_level = prog.use_weather ? os.options[OPTION_WATER_PERCENTAGE] : 100;
+  }
+
+  m->start = pgm->st - (int32_t)3600 / 4 * (int32_t)(os.options[OPTION_TIMEZONE] - 48);
+  m->end = pgm->et - (int32_t)3600 / 4 * (int32_t)(os.options[OPTION_TIMEZONE] - 48);
+  m->duration = m->end - m->start;
+
+  if (pgm->volume > 0 && os.options[OPTION_SENSOR_TYPE] == SENSOR_TYPE_FLOW) {
+    m->volume = pgm->volume * ((os.options[OPTION_PULSE_RATE_1] << 8) + os.options[OPTION_PULSE_RATE_0]) / 100.0;
+    m->flow = (m->duration == 0) ? 0 : m->volume * 60.0 / m->duration;
+  }
+}
+
+void helper_populate_stn_message(push_msg_t * m, RuntimeQueueStruct * q)
+{
+  m->id = q->sid;
+  os.get_station_name(q->sid, m->name);
+  if (!m->name) strcpy_P(m->name, PSTR("Unknown"));
+  m->start = q->st - (int32_t)3600 / 4 * (int32_t)(os.options[OPTION_TIMEZONE] - 48);
+  m->end = m->start + q->dur;
+  m->duration = q->dur;
+  m->water_level = q->wl;
+
+  if (q->volume > 0 && os.options[OPTION_SENSOR_TYPE] == SENSOR_TYPE_FLOW) {
+    m->volume = q->volume * ((os.options[OPTION_PULSE_RATE_1] << 8) + os.options[OPTION_PULSE_RATE_0]) / 100.0;
+    m->flow = (m->duration == 0) ? 0 : m->volume * 60.0 / m->duration;
+  }
+}
+
+#define helper_populate_time_fields(m, s, e, d) {m.start = s; m.end = e; m.duration = d;}
+
+void push_program_schedule(RuntimePgmStruct * pgm) {
+  push_msg_t m = { 0 };
+  helper_populate_pgm_message(&m, pgm);
+  push_message(now(), NOTIF_PROGRAM_SCHEDULE, &m);
+}
+
+void push_program_start(RuntimePgmStruct * pgm) {
+  push_msg_t m = { 0 };
+  helper_populate_pgm_message(&m, pgm);
+  push_message(now(), NOTIF_PROGRAM_START, &m);
+}
+
+void push_program_stop(RuntimePgmStruct * pgm) {
+  push_msg_t m = { 0 };
+  helper_populate_pgm_message(&m, pgm);
+  push_message(now(), NOTIF_PROGRAM_STOP, &m);
+}
+
+void push_station_schedule(RuntimeQueueStruct * q) {
+  push_msg_t m = { 0 };
+  helper_populate_stn_message(&m, q);
+  push_message(now(), NOTIF_STATION_SCHEDULE, &m);
+}
+
+void push_station_open(RuntimeQueueStruct * q) {
+  push_msg_t m = { 0 };
+  helper_populate_stn_message(&m, q);
+  push_message(now(), NOTIF_STATION_OPEN, &m);
+}
+
+void push_station_close(RuntimeQueueStruct * q) {
+  push_msg_t m = { 0 };
+  helper_populate_stn_message(&m, q);
+  push_message(now(), NOTIF_STATION_CLOSE, &m);
+}
+
+void push_weather_update(boolean success) {
+  push_msg_t m = { 0 };
+  m.start = now();
+  push_message(now(), (success == true) ? NOTIF_WEATHERCALL_SUCCESS : NOTIF_WEATHERCALL_FAIL, &m);
+}
+
+void push_waterlevel_update(byte water_level) {
+  push_msg_t m = { 0 };
+  m.start = now();
+  m.water_level = water_level;
+  push_message(now(), NOTIF_WATERLEVEL_UPDATE, &m);
+}
+
+void push_flow_update(float volume, ulong duration) {
+  push_msg_t m = { 0 };
+
+  helper_populate_time_fields(m, now() - duration, now(), duration);
+  m.volume = volume;
+  m.flow = (duration == 0) ? 0 : volume * 60.0 / duration;
+  push_message(now(), NOTIF_FLOW_UPDATE, &m);
+}
+
+void push_ip_update(ulong ip) {
+  push_msg_t m = { 0 };
+  m.start = now();
+  m.ip = ip;
+  push_message(now(), NOTIF_IP_UPDATE, &m);
+}
+
+void push_raindelay_start(ulong duration) {
+  push_msg_t m = { 0 };
+
+  helper_populate_time_fields(m, now(), now() + duration, duration);
+  push_message(now(), NOTIF_RAINDELAY_START, &m);
+}
+
+void push_raindelay_stop(ulong duration) {
+  push_msg_t m = { 0 };
+  helper_populate_time_fields(m, now() - duration, now(), duration);
+  push_message(now(), NOTIF_RAINDELAY_STOP, &m);
+}
+
+void push_rainsensor_on(void) {
+  push_msg_t m = { 0 };
+  m.start = now();
+  push_message(now(), NOTIF_RAINSENSOR_ON, &m);
+}
+
+void push_rainsensor_off(ulong duration) {
+  push_msg_t m = { 0 };
+  helper_populate_time_fields(m, now() - duration, now(), duration);
+  push_message(now(), NOTIF_RAINSENSOR_OFF, &m);
+}
+
+void push_reboot_complete(void) {
+  push_msg_t m = { 0 };
+  m.start = now();
+  push_message(now(), NOTIF_REBOOT_COMPLETE, &m);
+}
+
+// ==========================================
+// NOTIFICATION HANDLER
+// ==========================================
+
+void push_message(ulong timestamp, notification_t type, push_msg_t * msg) {
+  push_ifttt_message(timestamp, type, msg);
+  push_influxdb_message(timestamp, type, msg);
+  push_webhook_message(timestamp, type, msg);
+}
+
+// ==========================================
+// NOTIFICATION FUNCTIONS
+// ==========================================
+
+void push_ifttt_message(ulong timestamp, notification_t type, push_msg_t * m) {
+  const char * server PROGMEM = DEFAULT_IFTTT_URL;
+  const char * path_str PROGMEM = "/trigger/%s/with/key/";
+  char path[sizeof(path_str)/sizeof(char) + IFTTT_EVENT_MAXSIZE + 1] = { 0 };
+  char events[IFTTT_EVENT_MAXNUM][IFTTT_EVENT_MAXSIZE + 1] = { 0 };
+  char key[IFTTT_KEY_MAXSIZE + 1] = { 0 };
+
+  if ((ifttt_map[type] & os.options[OPTION_IFTTT_ENABLE]) == 0) return;
+
+  read_from_file(ifkey_filename, key, sizeof(key), 0);
+  if (strlen(key) == 0) return;
+
+  read_from_file(ifttt_filename, tmp_buffer);
+  if (strlen(tmp_buffer) == 0) {
+    sprintf_P(path, PSTR(path_str), "sprinkler", key);
+  } else {
+    // File contains event endpoints in json format: "events":["events":["event1", ... ,"event8"]
+    sscanf_P(tmp_buffer, PSTR("\"events\":[\"%[^\"]\",\"%[^\"]\",\"%[^\"]\",\"%[^\"]\",\"%[^\"]\",\"%[^\"]\",\"%[^\"]\",\"%[^\"]\""),
+           events[0], events[1], events[2], events[3], events[4], events[5], events[6], events[7]);
+
+    int pos = ffs(ifttt_map[type]) - 1;
+    sprintf_P(path, PSTR(path_str), events[pos]);
+  }
+
+  // Populate all three parameters with: value1 = human text, value2 = full json, value3 = most applicable single value
+  sprintf_P(post_buff, PSTR("{\"value1\":"));
+  if (format_text_msg(post_buff + strlen(post_buff), timestamp, type, m) > 0) {
+    strcat_P(post_buff, PSTR(",\"value2\":"));
+    if (format_json_msg(post_buff + strlen(post_buff), timestamp, type, m) > 0) {
+      strcat_P(post_buff, PSTR(",\"value3\":"));
+      if (format_value_msg(post_buff + strlen(post_buff), timestamp, type, m) > 0) {
+        strcat_P(post_buff, PSTR("}"));
+        DEBUG_PRINTLN(post_buff);
+        post_msg(server, 80, path, key, post_buff);
+      }
+    }
+  }
+}
+
+void push_influxdb_message(ulong timestamp, notification_t type, push_msg_t * m) {
+  const char * path PROGMEM = "/write?db=";
+  char server[INFLUX_SERVER_MAXSIZE + 1] = { 0 };
+  char db[INFLUX_DATABASE_MAXSIZE + 1] = { 0 };
+  int port = 0, enable= 0;
+
+  // File contains server, port and database settings
+  read_from_file(influx_filename, tmp_buffer);
+  if (strlen(tmp_buffer) == 0) return;
+  sscanf_P(tmp_buffer, PSTR("\"server\":\"%[^\"]\",\"port\":\%d,\"db\":\"%[^\"]\",\"enable\":\%d"), server, &port, db, &enable);
+  if (enable == 0) return;
+
+  if (format_influx_msg(post_buff, timestamp, type, m) > 0) {
+    DEBUG_PRINTLN(post_buff);
+    post_msg(server, port, path, db, post_buff);
+  }
+}
+
+void push_webhook_message(ulong timestamp, notification_t type, push_msg_t * m) {
+  char server[WEBHOOK_SERVER_MAXSIZE + 1] = { 0 };
+  int port = 0, enable = 0;
+
+  // Parameters stored as: "server":"server_name","port":port_number
+  read_from_file(webhook_filename, tmp_buffer);
+  if (strlen(tmp_buffer) == 0) return;
+  sscanf_P(tmp_buffer, PSTR("\"server\":\"%[^\"]\",\"port\":\%d,\"enable\":\%d"), server, &port, &enable);
+  if (enable == 0) return;
+
+  if (format_json_msg(post_buff, timestamp, type, m) > 0) {
+    DEBUG_PRINTLN(post_buff);
+    post_msg(server, port, "", "", post_buff);
+  }
+}
+
+// ==========================================
+// NOTIFICATION FORMATTERS
+// ==========================================
+
+int format_value_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m) {
+  switch(type) {
+
+    case NOTIF_STATION_SCHEDULE:
+    case NOTIF_STATION_OPEN:
+    case NOTIF_STATION_CLOSE:
+    case NOTIF_PROGRAM_SCHEDULE:
+    case NOTIF_PROGRAM_START:
+    case NOTIF_PROGRAM_STOP:
+      sprintf_P(buff, PSTR("\"%s\""), (m->name) ? m->name : "Unknown");
+    break;
+
+    case NOTIF_RAINSENSOR_ON:
+    case NOTIF_RAINSENSOR_OFF:
+      sprintf_P(buff, PSTR("%d"), (type == NOTIF_RAINSENSOR_ON) ? 1 : 0);
+    break;
+
+    case NOTIF_RAINDELAY_START:
+      sprintf_P(buff, PSTR("%lu"), m->duration);
+    break;
+
+    case NOTIF_RAINDELAY_STOP:
+      sprintf_P(buff, PSTR("%lu"), m->duration);
+    break;
+
+    case NOTIF_FLOW_UPDATE:
+      sprintf_P(buff, PSTR("%d.%02d"), (int)m->flow, ((int)(m->flow * 100) % 100));
+    break;
+
+    case NOTIF_WEATHERCALL_FAIL:
+    case NOTIF_WEATHERCALL_SUCCESS:
+      sprintf_P(buff, PSTR("%d"), (type == NOTIF_WEATHERCALL_FAIL) ? 0 : 1);
+    break;
+
+    case NOTIF_WATERLEVEL_UPDATE:
+      sprintf_P(buff, PSTR("%d"), m->water_level);
+    break;
+
+    case NOTIF_IP_UPDATE:
+      sprintf_P(buff, PSTR("\"%d.%d.%d.%d\""),
+                (byte)(m->ip >> 24) & 0xFF, (byte)(m->ip >> 16) & 0xFF, (byte)(m->ip >> 8) & 0xFF, (byte)m->ip & 0xFF);
+    break;
+
+    case NOTIF_REBOOT_COMPLETE:
+      #if defined(ARDUINO)
+        sprintf_P(buff, PSTR("\"Reboot\""));
+      #else
+        sprintf_P(buff, PSTR("\"Restart\""));
+      #endif
+    break;
+
+    default:
+      return 0;
+  }
+
+  return strlen(buff);
+}
+
+int format_text_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m) {
+  char unit[NAME_SIZE + 1] = { 0 };
+  char * offset = buff;
+
+  read_from_file(name_filename, unit, sizeof(unit), 0);
+  if (strlen(unit) != 0)
+    offset = buff + sprintf_P(buff, PSTR("\"%s: "), unit);
+
+  switch(type) {
+
+    case NOTIF_STATION_SCHEDULE:
+      sprintf_P(offset, PSTR("Station %s scheduled for %lu mins %lu sec with water level of %d%%."),
+                m->name, m->duration / 60, m->duration % 60, m->water_level);
+    break;
+
+    case NOTIF_STATION_OPEN:
+      sprintf_P(offset, PSTR("Station %s running for %lu mins %lu secs with water level of %d%%."),
+                m->name, m->duration / 60,  m->duration % 60, m->water_level);
+    break;
+
+    case NOTIF_STATION_CLOSE:
+      sprintf_P(offset, PSTR("Station %s ran for %lu mins %lu secs with volume of %d.%02d and flow rate at %d.%02d."),
+                m->name, m->duration / 60, m->duration % 60, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
+    break;
+
+    case NOTIF_PROGRAM_SCHEDULE:
+      sprintf_P(offset, PSTR("Program %s scheduled for %lu mins %lu sec with water level of %d%%."),
+                m->name, m->duration / 60, m->duration % 60, m->water_level);
+    break;
+
+    case NOTIF_PROGRAM_START:
+      sprintf_P(offset, PSTR("Program %s running for %lu mins %lu sec with water level of %d%%."),
+                m->name, m->duration / 60, m->duration % 60, m->water_level);
+    break;
+
+    case NOTIF_PROGRAM_STOP:
+      sprintf_P(offset, PSTR("Program %s ran for %lu mins %lu sec with water volume of %d.%02d and flow rate at %d.%02d."),
+                m->name, m->duration / 60, m->duration % 60, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
+    break;
+
+    case NOTIF_RAINSENSOR_ON:
+    case NOTIF_RAINSENSOR_OFF:
+      sprintf_P(offset, PSTR("Rain sensor %s."), (type == NOTIF_RAINSENSOR_ON) ? "activated" : "de-activated");
+    break;
+
+    case NOTIF_RAINDELAY_START:
+      sprintf_P(offset, PSTR("Rain delay started for %lu mins %lu secs."), m->duration / 60, m->duration % 60);
+    break;
+
+    case NOTIF_RAINDELAY_STOP:
+      sprintf_P(offset, PSTR("Rain delay finished."));
+    break;
+
+    case NOTIF_FLOW_UPDATE:
+      sprintf_P(offset, PSTR("%d.%02d of water delivered at flow rate of %d.%02d during last %lu mins %lu sec."),
+                (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100), m->duration / 60, m->duration % 60);
+    break;
+
+    case NOTIF_WEATHERCALL_FAIL:
+    case NOTIF_WEATHERCALL_SUCCESS:
+        sprintf_P(offset, PSTR("Weather call %s."), (type == NOTIF_WEATHERCALL_FAIL) ? "Failed" : "Succeeded");
+    break;
+
+    case NOTIF_WATERLEVEL_UPDATE:
+      sprintf_P(offset, PSTR("Water level set to %d%%."), m->water_level);
+    break;
+
+    case NOTIF_IP_UPDATE:
+      sprintf_P(offset, PSTR("External IP address updated to %d.%d.%d.%d."),
+                (byte)(m->ip >> 24) & 0xFF, (byte)(m->ip >> 16) & 0xFF, (byte)(m->ip >> 8) & 0xFF, (byte)m->ip & 0xFF);
+    break;
+
+    case NOTIF_REBOOT_COMPLETE:
+      #if defined(ARDUINO)
+        strcat_P(offset, PSTR("Device rebooted."));
+      #else
+        strcat_P(offset, PSTR("Process restarted."));
+      #endif
+    break;
+
+    default:
+      return 0;
+  }
+
+  strcat_P(buff, PSTR("\""));
+  return strlen(buff);
+}
+
+int format_json_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m) {
+  char unit_name[NAME_SIZE+1] = { 0 };
+  char * offset = NULL;
+
+  read_from_file(name_filename, unit_name, sizeof(unit_name), 0);
+  offset = buff + sprintf_P(buff, PSTR("{\"timestamp\":%lu,"), timestamp);
+
+  switch(type) {
+
+    case NOTIF_PROGRAM_SCHEDULE:
+    case NOTIF_PROGRAM_START:
+    case NOTIF_STATION_SCHEDULE:
+    case NOTIF_STATION_OPEN:
+      sprintf_P(offset, PSTR("\"type\":\"%s\",\"data\":{\"unit\":\"%s\",\"id\":%d,\"name\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"water_level\":%d"),
+        (type == NOTIF_PROGRAM_SCHEDULE) ? "program_schedule" : (type == NOTIF_PROGRAM_START) ? "program_start" : (type == NOTIF_STATION_SCHEDULE) ? "station_schedule" : "station_open",
+        unit_name, m->id, m->name, m->start, m->end, m->duration, m->water_level);
+    break;
+
+    case NOTIF_PROGRAM_STOP:
+    case NOTIF_STATION_CLOSE:
+      sprintf_P(offset, PSTR("\"type\":\"%s\",\"data\":{\"unit\":\"%s\",\"id\":%d,\"name\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"water_level\":%d,\"volume\":%d.%02d,\"flow\":%d.%02d"),
+        (type == NOTIF_PROGRAM_STOP) ? "program_stop" : "station_close", unit_name, m->id, m->name, m->start, m->end, m->duration, m->water_level,(int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
+    break;
+
+    case NOTIF_RAINSENSOR_ON:
+      sprintf_P(offset, PSTR("\"type\":\"rain_sensor\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"status\":1"), unit_name, m->start);
+    break;
+
+    case NOTIF_RAINSENSOR_OFF:
+    case NOTIF_RAINDELAY_START:
+    case NOTIF_RAINDELAY_STOP:
+      sprintf_P(offset, PSTR("\"type\":\"%s\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"status\":%d"),
+        (type == NOTIF_RAINSENSOR_OFF) ? "rain_sensor" : "rain_delay", unit_name, m->start, m->end , m->duration, (type == NOTIF_RAINSENSOR_OFF) ? 0 : 1);
+    break;
+
+    case NOTIF_FLOW_UPDATE:
+      sprintf_P(offset, PSTR("\"type\":\"flow\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"volume\":%d.%02d,\"flow\":%d.%02d"),
+        unit_name, m->start, m->end , m->duration, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
+    break;
+
+    case NOTIF_WEATHERCALL_FAIL:
+    case NOTIF_WEATHERCALL_SUCCESS:
+      sprintf_P(offset, PSTR("\"type\":\"weather_call\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"status\":%d"), unit_name, m->start, (type == NOTIF_WEATHERCALL_FAIL) ? 0 : 1);
+    break;
+
+    case NOTIF_WATERLEVEL_UPDATE:
+      sprintf_P(offset, PSTR("\"type\":\"water_level\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"level\":%d"), unit_name, m->start, m->water_level);
+    break;
+
+    case NOTIF_IP_UPDATE:
+      sprintf_P(offset, PSTR("\"type\":\"ip_update\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"ip\":\"%d.%d.%d.%d\""),
+        unit_name, m->start, (byte)(m->ip >> 24) & 0xFF, (byte)(m->ip >> 16) & 0xFF, (byte)(m->ip >> 8) & 0xFF, (byte)m->ip & 0xFF);
+    break;
+
+    case NOTIF_REBOOT_COMPLETE:
+      sprintf_P(offset, PSTR("\"type\":\"reboot\",\"data\":{\"unit\":\"%s\",\"start\":%lu"), unit_name, m->start);
+    break;
+
+    default:
+      return 0;
+  }
+
+  strcat_P(buff, PSTR("}}"));
+  return strlen(buff);
+}
+
+int format_influx_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m) {
+  char unit_tag[NAME_SIZE+1] = { 0 };    // InfluxDB Tag - Name of the device
+  char name_tag[NAME_SIZE+1] = { 0 };    // InfluxDB Tag - Name of the program or station
+
+  read_from_file(name_filename, unit_tag, sizeof(unit_tag), 0);
+  strcpy(name_tag, (m->name) ? m->name : "Unknown");
+
+  // InfluxDB doesn't like spaces in tag names
+  strip_spaces(unit_tag);
+  strip_spaces(name_tag);
+
+  switch (type) {
+
+    case NOTIF_PROGRAM_SCHEDULE:
+    case NOTIF_PROGRAM_START:
+    case NOTIF_STATION_SCHEDULE:
+    case NOTIF_STATION_OPEN:
+      sprintf_P(buff, PSTR("%s,unit_tag=%s,name_tag=%s status=%d,id=%d,name=\"%s\",start=%lu000,end=%lu000,duration=%lu,water_level=%d"),
+        (type == NOTIF_PROGRAM_SCHEDULE || type == NOTIF_PROGRAM_START) ? "program" : "station", unit_tag, name_tag,
+        (type == NOTIF_PROGRAM_SCHEDULE || type == NOTIF_STATION_SCHEDULE) ? 1 : 2, m->id,
+        m->name, m->start, m->end, m->duration, m->water_level);
+    break;
+
+    case NOTIF_PROGRAM_STOP:
+    case NOTIF_STATION_CLOSE:
+      sprintf_P(buff, PSTR("%s,unit_tag=%s,name_tag=%s status=0,id=%d,name=\"%s\",start=%lu000,end=%lu000,duration=%lu,water_level=%d,volume=%d.%02d,flow=%d.%02d"),
+        (type == NOTIF_PROGRAM_STOP) ? "program" : "station", unit_tag, name_tag, m->id, m->name, m->start, m->end, m->duration,
+        m->water_level, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
+    break;
+
+    case NOTIF_RAINSENSOR_ON:
+    sprintf_P(buff, PSTR("rain_sensor,unit_tag=%s start=%lu000,status=1"), unit_tag, m->start);
+    break;
+
+    case NOTIF_RAINSENSOR_OFF:
+    case NOTIF_RAINDELAY_START:
+    case NOTIF_RAINDELAY_STOP:
+      sprintf_P(buff, PSTR("%s,unit_tag=%s start=%lu000,end=%lu000,duration=%lu,status=%d"),
+        (type == NOTIF_RAINSENSOR_OFF) ? "rain_sensor" : "rain_delay",
+        unit_tag, m->start, m->end, m->duration, (type == NOTIF_RAINSENSOR_OFF) ? 0 : 1);
+    break;
+
+    case NOTIF_FLOW_UPDATE:
+      sprintf_P(buff, PSTR("flow,unit_tag=%s start=%lu000,end=%lu000,duration=%lu,volume=%d.%02d,flow=%d.%02d"),
+        unit_tag, m->start, m->end , m->duration, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
+    break;
+
+    case NOTIF_WEATHERCALL_FAIL:
+    case NOTIF_WEATHERCALL_SUCCESS:
+      sprintf_P(buff, PSTR("weather_call,unit_tag=%s start=%lu000,status=%d"), unit_tag, m->start, (type == NOTIF_WEATHERCALL_FAIL) ? 0 : 1);
+    break;
+
+    case NOTIF_WATERLEVEL_UPDATE:
+      sprintf_P(buff, PSTR("water_level,unit_tag=%s start=%lu000,level=%d"), unit_tag, m->start, m->water_level);
+    break;
+
+    case NOTIF_IP_UPDATE:
+      sprintf_P(buff, PSTR("ip_update,unit_tag=%s start=%lu000,ip=\"%d.%d.%d.%d\""),
+        unit_tag, m->start, (byte)(m->ip >> 24) & 0xFF, (byte)(m->ip >> 16) & 0xFF, (byte)(m->ip >> 8) & 0xFF, (byte)m->ip & 0xFF);
+    break;
+
+    case NOTIF_REBOOT_COMPLETE:
+      sprintf_P(buff, PSTR("reboot,unit_tag=%s start=%lu000"), unit_tag, m->start);
+    break;
+
+  default:
+    return 0;
+  }
+
+// Commented out the following to let InfluxDB set the timestamps as OS uses second granularity
+// but if multiple messages in the same main loop then all will have the same timestamp
+
+// InfluxDB uses unix epoch in nanoseconds
+//  strcat_P(buff, PSTR(" "));
+//  itoa(timestamp, buff + strlen(buff), 10);
+//  strcat_P(buff, PSTR("000000000"));
+
+  return strlen(buff);
+}
+
+// ==========================================
+// HELPER FUNCTIONS
+// ==========================================
+void post_msg(const char * server, int port, const char * path, const char * var, const char * postval)
+{
+#if defined(ARDUINO)
+
+  uint16_t _port = ether.hisport; // make a copy of the original port
+  ether.hisport = port;
+
+  if (!ether.dnsLookup(server, true)) {
+    DEBUG_PRINT("Push Server not found: ");
+    DEBUG_PRINTLN(server);
+    ether.hisport = _port;
+    return;
+  }
+
+  ether.httpPostVar(path, server, var, postval, httpget_callback);
+  //PJB TODO: Make this use a timeout rather than loop
+  for (int l = 0; l < 100; l++)  ether.packetLoop(ether.packetReceive());
+  ether.hisport = _port;
+
+#else
+
+  EthernetClient client;
+  struct hostent *host;
+
+  host = gethostbyname(server);
+  if (!host) {
+    DEBUG_PRINT("Push Server not found: ");
+    DEBUG_PRINTLN(server);
+    return;
+  }
+
+  // Reduce the default timeout window from 2 minutes to 3 seconds (same as read timeout)
+  // Protects against locking up if the server/internet is not available
+  if (!client.connect((uint8_t*)host->h_addr, port, 3)) {
+    client.stop();
+    return;
+  }
+
+  char postBuffer[1500];
+  sprintf(postBuffer,  "POST %s%s HTTP/1.0\r\n"
+                       "Host: %s\r\n"
+                       "Accept: */*\r\n"
+                       "Content-Length: %lu\r\n"
+                       "Content-Type: application/json\r\n"
+                       "\r\n%s",
+                       path, var, host->h_name, strlen(postval), postval);
+
+  client.write((uint8_t *)postBuffer, strlen(postBuffer));
+  bzero(ether_buffer, ETHER_BUFFER_SIZE);
+
+  time_t timeout = now() + 5; // 5 seconds timeout
+  while (now() < timeout) {
+    int len = client.read((uint8_t *)ether_buffer, ETHER_BUFFER_SIZE);
+    if (len <= 0) {
+      if (!client.connected())
+        break;
+      else
+        continue;
+    }
+  }
+
+  client.stop();
+
+#endif
+}
+
+void strip_spaces(char * i) {
+  char * j = i;
+  while (*j != 0) { *i = *j++; if (*i != ' ') i++; }
+  *i = 0;
+}
+#endif

--- a/notifier.cpp
+++ b/notifier.cpp
@@ -426,12 +426,13 @@ int format_value_msg(char * buff, ulong timestamp, notification_t type, push_msg
 }
 
 int format_text_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m) {
-  char unit[NAME_SIZE + 1] = { 0 };
+  char site[NAME_SIZE + 1] = { 0 };
   char * offset = buff;
 
-  read_from_file(name_filename, unit, sizeof(unit), 0);
-  if (strlen(unit) != 0)
-    offset = buff + sprintf_P(buff, PSTR("\"%s: "), unit);
+  offset += sprintf_P(buff, PSTR("\""));
+  read_from_file(site_filename, site, sizeof(site), 0);
+  if (strlen(site) != 0)
+    offset += sprintf_P(offset, PSTR("%s: "), site);
 
   switch(type) {
 
@@ -514,10 +515,11 @@ int format_text_msg(char * buff, ulong timestamp, notification_t type, push_msg_
 }
 
 int format_json_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m) {
-  char unit_name[NAME_SIZE+1] = { 0 };
+  char site[NAME_SIZE+1] = { 0 };
   char * offset = NULL;
 
-  read_from_file(name_filename, unit_name, sizeof(unit_name), 0);
+  read_from_file(site_filename, site, sizeof(site), 0);
+  if (site[0] == NULL) strcpy_P(site, PSTR("Site"));
   offset = buff + sprintf_P(buff, PSTR("{\"timestamp\":%lu,"), timestamp);
 
   switch(type) {
@@ -526,49 +528,49 @@ int format_json_msg(char * buff, ulong timestamp, notification_t type, push_msg_
     case NOTIF_PROGRAM_START:
     case NOTIF_STATION_SCHEDULE:
     case NOTIF_STATION_OPEN:
-      sprintf_P(offset, PSTR("\"type\":\"%s\",\"data\":{\"unit\":\"%s\",\"id\":%d,\"name\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"water_level\":%d"),
+      sprintf_P(offset, PSTR("\"type\":\"%s\",\"data\":{\"site\":\"%s\",\"id\":%d,\"name\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"water_level\":%d"),
         (type == NOTIF_PROGRAM_SCHEDULE) ? "program_schedule" : (type == NOTIF_PROGRAM_START) ? "program_start" : (type == NOTIF_STATION_SCHEDULE) ? "station_schedule" : "station_open",
-        unit_name, m->id, m->name, m->start, m->end, m->duration, m->water_level);
+        site, m->id, m->name, m->start, m->end, m->duration, m->water_level);
     break;
 
     case NOTIF_PROGRAM_STOP:
     case NOTIF_STATION_CLOSE:
-      sprintf_P(offset, PSTR("\"type\":\"%s\",\"data\":{\"unit\":\"%s\",\"id\":%d,\"name\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"water_level\":%d,\"volume\":%d.%02d,\"flow\":%d.%02d"),
-        (type == NOTIF_PROGRAM_STOP) ? "program_stop" : "station_close", unit_name, m->id, m->name, m->start, m->end, m->duration, m->water_level,(int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
+      sprintf_P(offset, PSTR("\"type\":\"%s\",\"data\":{\"site\":\"%s\",\"id\":%d,\"name\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"water_level\":%d,\"volume\":%d.%02d,\"flow\":%d.%02d"),
+        (type == NOTIF_PROGRAM_STOP) ? "program_stop" : "station_close", site, m->id, m->name, m->start, m->end, m->duration, m->water_level,(int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
     break;
 
     case NOTIF_RAINSENSOR_ON:
-      sprintf_P(offset, PSTR("\"type\":\"rain_sensor\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"status\":1"), unit_name, m->start);
+      sprintf_P(offset, PSTR("\"type\":\"rain_sensor\",\"data\":{\"site\":\"%s\",\"start\":%lu,\"status\":1"), site, m->start);
     break;
 
     case NOTIF_RAINSENSOR_OFF:
     case NOTIF_RAINDELAY_START:
     case NOTIF_RAINDELAY_STOP:
-      sprintf_P(offset, PSTR("\"type\":\"%s\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"status\":%d"),
-        (type == NOTIF_RAINSENSOR_OFF) ? "rain_sensor" : "rain_delay", unit_name, m->start, m->end , m->duration, (type == NOTIF_RAINSENSOR_OFF) ? 0 : 1);
+      sprintf_P(offset, PSTR("\"type\":\"%s\",\"data\":{\"site\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"status\":%d"),
+        (type == NOTIF_RAINSENSOR_OFF) ? "rain_sensor" : "rain_delay", site, m->start, m->end , m->duration, (type == NOTIF_RAINDELAY_START) ? 1 : 0);
     break;
 
     case NOTIF_FLOW_UPDATE:
-      sprintf_P(offset, PSTR("\"type\":\"flow\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"volume\":%d.%02d,\"flow\":%d.%02d"),
-        unit_name, m->start, m->end , m->duration, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
+      sprintf_P(offset, PSTR("\"type\":\"flow\",\"data\":{\"site\":\"%s\",\"start\":%lu,\"end\":%lu,\"duration\":%lu,\"volume\":%d.%02d,\"flow\":%d.%02d"),
+        site, m->start, m->end , m->duration, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
     break;
 
     case NOTIF_WEATHERCALL_FAIL:
     case NOTIF_WEATHERCALL_SUCCESS:
-      sprintf_P(offset, PSTR("\"type\":\"weather_call\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"status\":%d"), unit_name, m->start, (type == NOTIF_WEATHERCALL_FAIL) ? 0 : 1);
+      sprintf_P(offset, PSTR("\"type\":\"weather_call\",\"data\":{\"site\":\"%s\",\"start\":%lu,\"status\":%d"), site, m->start, (type == NOTIF_WEATHERCALL_FAIL) ? 0 : 1);
     break;
 
     case NOTIF_WATERLEVEL_UPDATE:
-      sprintf_P(offset, PSTR("\"type\":\"water_level\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"level\":%d"), unit_name, m->start, m->water_level);
+      sprintf_P(offset, PSTR("\"type\":\"water_level\",\"data\":{\"site\":\"%s\",\"start\":%lu,\"level\":%d"), site, m->start, m->water_level);
     break;
 
     case NOTIF_IP_UPDATE:
-      sprintf_P(offset, PSTR("\"type\":\"ip_update\",\"data\":{\"unit\":\"%s\",\"start\":%lu,\"ip\":\"%d.%d.%d.%d\""),
-        unit_name, m->start, (byte)(m->ip >> 24) & 0xFF, (byte)(m->ip >> 16) & 0xFF, (byte)(m->ip >> 8) & 0xFF, (byte)m->ip & 0xFF);
+      sprintf_P(offset, PSTR("\"type\":\"ip_update\",\"data\":{\"site\":\"%s\",\"start\":%lu,\"ip\":\"%d.%d.%d.%d\""),
+        site, m->start, (byte)(m->ip >> 24) & 0xFF, (byte)(m->ip >> 16) & 0xFF, (byte)(m->ip >> 8) & 0xFF, (byte)m->ip & 0xFF);
     break;
 
     case NOTIF_REBOOT_COMPLETE:
-      sprintf_P(offset, PSTR("\"type\":\"reboot\",\"data\":{\"unit\":\"%s\",\"start\":%lu"), unit_name, m->start);
+      sprintf_P(offset, PSTR("\"type\":\"reboot\",\"data\":{\"site\":\"%s\",\"start\":%lu"), site, m->start);
     break;
 
     default:
@@ -580,15 +582,16 @@ int format_json_msg(char * buff, ulong timestamp, notification_t type, push_msg_
 }
 
 int format_influx_msg(char * buff, ulong timestamp, notification_t type, push_msg_t * m) {
-  char unit_tag[NAME_SIZE+1] = { 0 };    // InfluxDB Tag - Name of the device
-  char name_tag[NAME_SIZE+1] = { 0 };    // InfluxDB Tag - Name of the program or station
+  char site[NAME_SIZE+1] = { 0 };    // InfluxDB Tag - Name of the device site
+  char name[NAME_SIZE + 1] = { 0 };    // InfluxDB Tag - Name of the program or station
 
-  read_from_file(name_filename, unit_tag, sizeof(unit_tag), 0);
-  strcpy(name_tag, (m->name) ? m->name : "Unknown");
+  read_from_file(site_filename, site, sizeof(site), 0);
+  if (*site == NULL) strcpy_P(site, PSTR("Site"));
+  strcpy(name, m->name);
 
   // InfluxDB doesn't like spaces in tag names
-  strip_spaces(unit_tag);
-  strip_spaces(name_tag);
+  strip_spaces(site);
+  strip_spaces(name);
 
   switch (type) {
 
@@ -596,65 +599,57 @@ int format_influx_msg(char * buff, ulong timestamp, notification_t type, push_ms
     case NOTIF_PROGRAM_START:
     case NOTIF_STATION_SCHEDULE:
     case NOTIF_STATION_OPEN:
-      sprintf_P(buff, PSTR("%s,unit_tag=%s,name_tag=%s status=%d,id=%d,name=\"%s\",start=%lu000,end=%lu000,duration=%lu,water_level=%d"),
-        (type == NOTIF_PROGRAM_SCHEDULE || type == NOTIF_PROGRAM_START) ? "program" : "station", unit_tag, name_tag,
+      sprintf_P(buff, PSTR("%s,site_tag=%s,name_tag=%s,id_tag=%d status=%d,id=%d,name=\"%s\",start=%lu000,end=%lu000,duration=%lu,water_level=%d"),
+        (type == NOTIF_PROGRAM_SCHEDULE || type == NOTIF_PROGRAM_START) ? "program" : "station", site, name, m->id,
         (type == NOTIF_PROGRAM_SCHEDULE || type == NOTIF_STATION_SCHEDULE) ? 1 : 2, m->id,
         m->name, m->start, m->end, m->duration, m->water_level);
-    break;
+      break;
 
     case NOTIF_PROGRAM_STOP:
     case NOTIF_STATION_CLOSE:
-      sprintf_P(buff, PSTR("%s,unit_tag=%s,name_tag=%s status=0,id=%d,name=\"%s\",start=%lu000,end=%lu000,duration=%lu,water_level=%d,volume=%d.%02d,flow=%d.%02d"),
-        (type == NOTIF_PROGRAM_STOP) ? "program" : "station", unit_tag, name_tag, m->id, m->name, m->start, m->end, m->duration,
+      sprintf_P(buff, PSTR("%s,site_tag=%s,name_tag=%s,id_tag=%d status=0,id=%d,name=\"%s\",start=%lu000,end=%lu000,duration=%lu,water_level=%d,volume=%d.%02d,flow=%d.%02d"),
+        (type == NOTIF_PROGRAM_STOP) ? "program" : "station", site, name, m->id, m->id, m->name, m->start, m->end, m->duration,
         m->water_level, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
     break;
 
     case NOTIF_RAINSENSOR_ON:
-    sprintf_P(buff, PSTR("rain_sensor,unit_tag=%s start=%lu000,status=1"), unit_tag, m->start);
+      sprintf_P(buff, PSTR("rain_sensor,site_tag=%s start=%lu000,status=1"), site, m->start);
     break;
 
     case NOTIF_RAINSENSOR_OFF:
     case NOTIF_RAINDELAY_START:
     case NOTIF_RAINDELAY_STOP:
-      sprintf_P(buff, PSTR("%s,unit_tag=%s start=%lu000,end=%lu000,duration=%lu,status=%d"),
+      sprintf_P(buff, PSTR("%s,site_tag=%s start=%lu000,end=%lu000,duration=%lu,status=%d"),
         (type == NOTIF_RAINSENSOR_OFF) ? "rain_sensor" : "rain_delay",
-        unit_tag, m->start, m->end, m->duration, (type == NOTIF_RAINSENSOR_OFF) ? 0 : 1);
+        site, m->start, m->end, m->duration, (type == NOTIF_RAINDELAY_START) ? 1 : 0);
     break;
 
     case NOTIF_FLOW_UPDATE:
-      sprintf_P(buff, PSTR("flow,unit_tag=%s start=%lu000,end=%lu000,duration=%lu,volume=%d.%02d,flow=%d.%02d"),
-        unit_tag, m->start, m->end , m->duration, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
+      sprintf_P(buff, PSTR("flow,site_tag=%s start=%lu000,end=%lu000,duration=%lu,volume=%d.%02d,flow=%d.%02d"),
+        site, m->start, m->end , m->duration, (int)m->volume, ((int)(m->volume * 100) % 100), (int)m->flow, ((int)(m->flow * 100) % 100));
     break;
 
     case NOTIF_WEATHERCALL_FAIL:
     case NOTIF_WEATHERCALL_SUCCESS:
-      sprintf_P(buff, PSTR("weather_call,unit_tag=%s start=%lu000,status=%d"), unit_tag, m->start, (type == NOTIF_WEATHERCALL_FAIL) ? 0 : 1);
+      sprintf_P(buff, PSTR("weather_call,site_tag=%s start=%lu000,status=%d"), site, m->start, (type == NOTIF_WEATHERCALL_FAIL) ? 0 : 1);
     break;
 
     case NOTIF_WATERLEVEL_UPDATE:
-      sprintf_P(buff, PSTR("water_level,unit_tag=%s start=%lu000,level=%d"), unit_tag, m->start, m->water_level);
+      sprintf_P(buff, PSTR("water_level,site_tag=%s start=%lu000,level=%d"), site, m->start, m->water_level);
     break;
 
     case NOTIF_IP_UPDATE:
-      sprintf_P(buff, PSTR("ip_update,unit_tag=%s start=%lu000,ip=\"%d.%d.%d.%d\""),
-        unit_tag, m->start, (byte)(m->ip >> 24) & 0xFF, (byte)(m->ip >> 16) & 0xFF, (byte)(m->ip >> 8) & 0xFF, (byte)m->ip & 0xFF);
+      sprintf_P(buff, PSTR("ip_update,site_tag=%s start=%lu000,ip=\"%d.%d.%d.%d\""),
+        site, m->start, (byte)(m->ip >> 24) & 0xFF, (byte)(m->ip >> 16) & 0xFF, (byte)(m->ip >> 8) & 0xFF, (byte)m->ip & 0xFF);
     break;
 
     case NOTIF_REBOOT_COMPLETE:
-      sprintf_P(buff, PSTR("reboot,unit_tag=%s start=%lu000"), unit_tag, m->start);
+      sprintf_P(buff, PSTR("reboot,site_tag=%s start=%lu000"), site, m->start);
     break;
 
   default:
     return 0;
   }
-
-// Commented out the following to let InfluxDB set the timestamps as OS uses second granularity
-// but if multiple messages in the same main loop then all will have the same timestamp
-
-// InfluxDB uses unix epoch in nanoseconds
-//  strcat_P(buff, PSTR(" "));
-//  itoa(timestamp, buff + strlen(buff), 10);
-//  strcat_P(buff, PSTR("000000000"));
 
   return strlen(buff);
 }

--- a/notifier.h
+++ b/notifier.h
@@ -1,0 +1,60 @@
+/* OpenSprinkler Unified (AVR/RPI/BBB/LINUX) Firmware
+ * Copyright (C) 2015 by Ray Wang (ray@opensprinkler.com)
+ *
+ * Notifier data structures and functions header file
+ * Feb 2015 @ OpenSprinkler.com
+ *
+ * This file is part of the OpenSprinkler library
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>. 
+ */
+
+#ifndef _NOTIFIER_H
+#define _NOTIFIER_H
+
+#if !defined(ARDUINO) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega1284__)
+void push_program_schedule(RuntimePgmStruct * pgm);
+void push_program_start(RuntimePgmStruct * pgm);
+void push_program_stop(RuntimePgmStruct * pgm);
+void push_station_schedule(RuntimeQueueStruct * q);
+void push_station_open(RuntimeQueueStruct * q);
+void push_station_close(RuntimeQueueStruct * q);
+void push_weather_update(boolean success); 
+void push_waterlevel_update(byte water_level);
+void push_flow_update(float volume, ulong duration);
+void push_ip_update(ulong ip);
+void push_raindelay_start(ulong duration);
+void push_raindelay_stop(ulong duration);
+void push_rainsensor_on(void);
+void push_rainsensor_off(ulong duration);
+void push_reboot_complete(void);
+#else
+#define push_program_schedule(pgm) {};
+#define push_program_start(pgm) {};
+#define push_program_stop(pgm) {};
+#define push_station_schedule(q) {};
+#define push_station_open(q) {};
+#define push_station_close(q) {};
+#define push_weather_update(success) {};
+#define push_waterlevel_update(water_level) {};
+#define push_flow_update(volume, duration) {};
+#define push_ip_update(ip) {};
+#define push_raindelay_start(duration) {};
+#define push_raindelay_stop(duration) {};
+#define push_rainsensor_on() {};
+#define push_rainsensor_off(duration) {};
+#define push_reboot_complete() {};
+#endif
+#endif  // _NOTIFIER_H

--- a/program.h
+++ b/program.h
@@ -131,10 +131,26 @@ extern OpenSprinkler os;
 
 class RuntimeQueueStruct {
 public:
+  ulong timestamp;
   ulong    st;  // start time
   uint16_t dur; // water time
   byte  sid;
   byte  pid;
+  byte wl;      // water level
+  float volume;
+  bool running;
+  class RuntimePgmStruct * pgm;
+};
+
+class RuntimePgmStruct {
+public:
+  ulong timestamp;
+  byte pid;
+  ulong st;
+  ulong et;
+  float volume;
+  byte count;
+  bool running;
 };
 
 class ProgramData {
@@ -147,8 +163,12 @@ public:
   static ulong last_seq_stop_time;  // the last stop time of a sequential station
   
   static void reset_runtime();
-  static RuntimeQueueStruct* enqueue(); // this returns a pointer to the next available slot in the queue
-  static void dequeue(byte qid);  // this removes an element from the queue
+  static boolean queue_full();
+  static RuntimeQueueStruct* enqueue(RuntimeQueueStruct* q); // this returns a pointer to the next available slot in the queue
+  static void dequeue(RuntimeQueueStruct* q);  // this removes an element from the queue
+  static void schedule(RuntimeQueueStruct * q, ulong st); // Schedule the elemt and fix various queues
+  static void cancel(RuntimeQueueStruct * q); // Cancel the run by setting duration to zero
+  static void print_queue(); // Print out the queue and pgm_queue for debugging
 
   static void init();
   static void eraseall();
@@ -159,9 +179,12 @@ public:
   static byte del(byte pid);
   static void drem_to_relative(byte days[2]); // absolute to relative reminder conversion
   static void drem_to_absolute(byte days[2]);
-private:  
+private:
   static void load_count();
   static void save_count();
+  static RuntimePgmStruct pgm_queue[];
+  static byte pgm_nqueue;
+  static byte program_qid[];  // this array stores the queue element index for each scheduled program
 };
 
 #endif  // _PROGRAM_H

--- a/server.cpp
+++ b/server.cpp
@@ -1219,6 +1219,18 @@ void server_json_controller_main() {
   if(read_from_file(ifkey_filename, tmp_buffer)) {
     bfill.emit_p(PSTR(",\"ifkey\":\"$S\""), tmp_buffer);
   }
+  if(read_from_file(ifttt_filename, tmp_buffer)) {
+    bfill.emit_p(PSTR(",\"ifttt\":{$S}"), tmp_buffer);
+  }
+  if (read_from_file(webhook_filename, tmp_buffer)) {
+	  bfill.emit_p(PSTR(",\"webhook\":{$S}"), tmp_buffer);
+  }
+  if (read_from_file(influx_filename, tmp_buffer)) {
+	  bfill.emit_p(PSTR(",\"influx\":{$S}"), tmp_buffer);
+  }
+  if (read_from_file(name_filename, tmp_buffer)) {
+	  bfill.emit_p(PSTR(",\"name\":\"$S\""), tmp_buffer);
+  }
 #endif
 
 #ifdef ESP8266
@@ -1478,7 +1490,43 @@ void server_change_options()
   } else if (keyfound) {
     tmp_buffer[0]=0;
     write_to_file(ifkey_filename, tmp_buffer, strlen(tmp_buffer));
-  }  
+  }
+  keyfound = 0;
+  if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("ifttt"), true, &keyfound)) {
+    urlDecode(tmp_buffer);
+    tmp_buffer[TMP_BUFFER_SIZE-1]=0;
+    write_to_file(ifttt_filename, tmp_buffer, strlen(tmp_buffer));
+  } else if (keyfound) {
+    tmp_buffer[0]=0;
+    write_to_file(ifttt_filename, tmp_buffer, strlen(tmp_buffer));
+  }
+  keyfound = 0;
+  if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("influx"), true, &keyfound)) {
+    urlDecode(tmp_buffer);
+    tmp_buffer[TMP_BUFFER_SIZE-1]=0;
+    write_to_file(influx_filename, tmp_buffer, strlen(tmp_buffer));
+  } else if (keyfound) {
+    tmp_buffer[0]=0;
+    write_to_file(influx_filename, tmp_buffer, strlen(tmp_buffer));
+  }
+  keyfound = 0;
+  if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("webhook"), true, &keyfound)) {
+    urlDecode(tmp_buffer);
+    tmp_buffer[TMP_BUFFER_SIZE-1]=0;
+    write_to_file(webhook_filename, tmp_buffer, strlen(tmp_buffer));
+  } else if (keyfound) {
+    tmp_buffer[0]=0;
+    write_to_file(webhook_filename, tmp_buffer, strlen(tmp_buffer));
+  }
+  keyfound = 0;
+  if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("name"), true, &keyfound)) {
+    urlDecode(tmp_buffer);
+    tmp_buffer[TMP_BUFFER_SIZE-1]=0;
+    write_to_file(name_filename, tmp_buffer, strlen(tmp_buffer));
+  } else if (keyfound) {
+    tmp_buffer[0]=0;
+    write_to_file(name_filename, tmp_buffer, strlen(tmp_buffer));
+  }
   // if not using NTP and manually setting time
   if (!os.options[OPTION_USE_NTP] && findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("ttt"), true)) {
     unsigned long t;

--- a/server.cpp
+++ b/server.cpp
@@ -836,6 +836,7 @@ void server_change_runonce() {
   byte sid, bid, s;
   uint16_t dur;
   boolean match_found = false;
+  ulong timestamp = os.now_tz();
   for(sid=0;sid<os.nstations;sid++) {
     dur=parse_listdata(&pv);
     bid=sid>>3;
@@ -843,12 +844,17 @@ void server_change_runonce() {
     // if non-zero duration is given
     // and if the station has not been disabled
     if (dur>0 && !(os.station_attrib_bits_read(ADDR_NVM_STNDISABLE+bid)&(1<<s))) {
-      RuntimeQueueStruct *q = pd.enqueue();
-      if (q) {
-        q->st = 0;
-        q->dur = water_time_resolve(dur);
-        q->pid = 254;
-        q->sid = sid;
+      if (!pd.queue_full()) {
+        RuntimeQueueStruct q = { 0 };
+        q.timestamp = timestamp;
+        q.sid = sid;
+        q.pid = 254;
+        q.st = 0;
+        q.dur = water_time_resolve(dur);
+		q.wl = 100;
+        q.volume = 0;
+        q.running = false;
+        pd.enqueue(&q);
         match_found = true;
       }
     }
@@ -1615,21 +1621,27 @@ void server_change_manual() {
       if ((os.status.mas==sid+1) || (os.status.mas2==sid+1))
         handle_return(HTML_NOT_PERMITTED);
 
-      RuntimeQueueStruct *q = NULL;
       byte sqi = pd.station_qid[sid];
       // check if the station already has a schedule
       if (sqi!=0xFF) {  // if we, we will overwrite the schedule
-        q = pd.queue+sqi;
-      } else {  // otherwise create a new queue element
-        q = pd.enqueue();
+        // Reset the end time to stop current station during the next scheduling loop
+        // Ensures any push notifications are sent correctly
+        turn_off_station(sid, curr_time);
       }
       // if the queue is not full
-      if (q) {
-        q->st = 0;
-        q->dur = timer;
-        q->sid = sid;
-        q->pid = 99;  // testing stations are assigned program index 99
+      if (!pd.queue_full()) {
+        RuntimeQueueStruct q = { 0 };
+        q.timestamp = curr_time;
+        q.sid = sid;
+        q.pid = 99;  // testing stations are assigned program index 99
+        q.st = 0;
+        q.dur = timer;
+        q.wl = 100;
+        q.volume = 0;
+        q.running = false;
+        pd.enqueue(&q);
         schedule_all_stations(curr_time);
+        pd.print_queue();
       } else {
         handle_return(HTML_NOT_PERMITTED);
       }

--- a/server.cpp
+++ b/server.cpp
@@ -1228,8 +1228,8 @@ void server_json_controller_main() {
   if (read_from_file(influx_filename, tmp_buffer)) {
 	  bfill.emit_p(PSTR(",\"influx\":{$S}"), tmp_buffer);
   }
-  if (read_from_file(name_filename, tmp_buffer)) {
-	  bfill.emit_p(PSTR(",\"name\":\"$S\""), tmp_buffer);
+  if (read_from_file(site_filename, tmp_buffer)) {
+	  bfill.emit_p(PSTR(",\"site\":\"$S\""), tmp_buffer);
   }
 #endif
 
@@ -1519,13 +1519,13 @@ void server_change_options()
     write_to_file(webhook_filename, tmp_buffer, strlen(tmp_buffer));
   }
   keyfound = 0;
-  if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("name"), true, &keyfound)) {
+  if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("site"), true, &keyfound)) {
     urlDecode(tmp_buffer);
     tmp_buffer[TMP_BUFFER_SIZE-1]=0;
-    write_to_file(name_filename, tmp_buffer, strlen(tmp_buffer));
+    write_to_file(site_filename, tmp_buffer, strlen(tmp_buffer));
   } else if (keyfound) {
     tmp_buffer[0]=0;
-    write_to_file(name_filename, tmp_buffer, strlen(tmp_buffer));
+    write_to_file(site_filename, tmp_buffer, strlen(tmp_buffer));
   }
   // if not using NTP and manually setting time
   if (!os.options[OPTION_USE_NTP] && findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("ttt"), true)) {

--- a/weather.cpp
+++ b/weather.cpp
@@ -315,6 +315,7 @@ void GetWeather() {
         continue;
     }
     peel_http_header();
+    DEBUG_PRINTLN(ether_buffer);
     getweather_callback(0, 0, ETHER_BUFFER_SIZE);
     break;
   }

--- a/weather.cpp
+++ b/weather.cpp
@@ -44,6 +44,7 @@ extern OpenSprinkler os; // OpenSprinkler object
 extern char tmp_buffer[];
 byte findKeyVal (const char *str,char *strbuf, uint8_t maxlen,const char *key,bool key_in_pgm=false,uint8_t *keyfound=NULL);
 void write_log(byte type, ulong curr_time);
+static bool get_completed = false;
 
 // The weather function calls getweather.py on remote server to retrieve weather data
 // the default script is WEATHER_SCRIPT_HOST/weather?.py
@@ -52,6 +53,8 @@ void write_log(byte type, ulong curr_time);
 static void getweather_callback(byte status, uint16_t off, uint16_t len) {
 #if defined(ARDUINO) && !defined(ESP8266)
   char *p = (char*)Ethernet::buffer + off;
+  get_completed = true;
+  DEBUG_PRINTLN(p);
 #else
   char *p = ether_buffer;
 #endif
@@ -222,6 +225,16 @@ void GetWeather() {
   uint16_t _port = ether.hisport; // save current port number
   ether.hisport = 80;
   ether.browseUrl(PSTR("/weather"), dst, PSTR("*"), getweather_callback);
+  DEBUG_PRINTLN(dst);
+
+  unsigned long start = millis();
+  get_completed = false;
+  while ((millis() - start < 5000) && (get_completed == false))
+    ether.packetLoop(ether.packetReceive());
+
+  if (!get_completed)
+    DEBUG_PRINTLN("Weather call timed out.");
+
   ether.hisport = _port;
 #endif
 }


### PR DESCRIPTION
This PR (and the associated PR for App) addresses three objectives with OpenSprinkler:
- Extend notification integration to get real-time OS event/usage into InfluxDb
- Get water usage at the Station and Program level rather than across a combined run
- Provide monitoring of flow rate to allow triggering of alarms if too high (i.e. leak/cut pipe)

During the process of implementing the above, the following have also been included:
- Specifying endpoints for IFTTT triggers so that you can send some events to, say, a spreadsheet log, and other to a phone notification
- Adding richer data to the notification messages i.e. Station End event also contains start/finish times, water level used, water volume usage and average flow rate
- Adding a generic WebHook interface for notifications that other services could hook onto. This is only “outbound” notifications and not an api.
- Allowing a “name” to be assigned to the unit that is sent with the notification to aid identification in multi-OS environments

In order to implement the above, the PRs have made a number of significant changes to both Firmware and App that require review:
- Generalised the IFTTT notification handler and UI to support multiple destinations (IFTTT, InfluxDb, WebHook)
- Moved much of the scheduling code from main.cpp to program.cpp to allow pre- and post- process of station and program scheduling
- Added flow volume to be apportioned across each of the running stations (done in a uniform distribution)

I have attached a comment to each of the commits below that sets out the headlines changes and attempts to explain some of the change rationale. In addition, there are a few questions that I would very much appreciate some feedback on that I have attached in the following PR level comment.

Appreciate your feedback and happy to take any modifications on-board.