### PR TITLE
Ethernet support for 3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nvm.dat
 OpenSprinkler
 wtopts.txt
 stns.dat
+bin/**

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -1,0 +1,175 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2015 by Fabrice Weinberg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "NTPClient.h"
+
+NTPClient::NTPClient(UDP& udp) {
+  this->_udp            = &udp;
+}
+
+NTPClient::NTPClient(UDP& udp, long timeOffset) {
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset;
+}
+
+NTPClient::NTPClient(UDP& udp, const char* poolServerName) {
+  this->_udp            = &udp;
+  this->_poolServerName = poolServerName;
+}
+
+NTPClient::NTPClient(UDP& udp, const char* poolServerName, long timeOffset) {
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset;
+  this->_poolServerName = poolServerName;
+}
+
+NTPClient::NTPClient(UDP& udp, const char* poolServerName, long timeOffset, unsigned long updateInterval) {
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset;
+  this->_poolServerName = poolServerName;
+  this->_updateInterval = updateInterval;
+}
+
+void NTPClient::begin() {
+  this->begin(NTP_DEFAULT_LOCAL_PORT);
+}
+
+void NTPClient::begin(int port) {
+  this->_port = port;
+
+  this->_udp->begin(this->_port);
+
+  this->_udpSetup = true;
+}
+
+bool NTPClient::forceUpdate() {
+  #ifdef DEBUG_NTPClient
+    Serial.println("Update from NTP Server");
+  #endif
+
+  this->sendNTPPacket();
+
+  // Wait till data is there or timeout...
+  byte timeout = 0;
+  int cb = 0;
+  do {
+    delay ( 10 );
+    cb = this->_udp->parsePacket();
+    if (timeout > 100) return false; // timeout after 1000 ms
+    timeout++;
+  } while (cb == 0);
+
+  this->_lastUpdate = millis() - (10 * (timeout + 1)); // Account for delay in reading the time
+
+  this->_udp->read(this->_packetBuffer, NTP_PACKET_SIZE);
+
+  unsigned long highWord = word(this->_packetBuffer[40], this->_packetBuffer[41]);
+  unsigned long lowWord = word(this->_packetBuffer[42], this->_packetBuffer[43]);
+  // combine the four bytes (two words) into a long integer
+  // this is NTP time (seconds since Jan 1 1900):
+  unsigned long secsSince1900 = highWord << 16 | lowWord;
+
+  this->_currentEpoc = secsSince1900 - SEVENZYYEARS;
+
+  return true;
+}
+
+bool NTPClient::update() {
+  if ((millis() - this->_lastUpdate >= this->_updateInterval)     // Update after _updateInterval
+    || this->_lastUpdate == 0) {                                // Update if there was no update yet.
+    if (!this->_udpSetup) this->begin();                         // setup the UDP client if needed
+    return this->forceUpdate();
+  }
+  return true;
+}
+
+unsigned long NTPClient::getEpochTime() const {
+  return this->_timeOffset + // User offset
+         this->_currentEpoc + // Epoc returned by the NTP server
+         ((millis() - this->_lastUpdate) / 1000); // Time since last update
+}
+
+int NTPClient::getDay() const {
+  return (((this->getEpochTime()  / 86400L) + 4 ) % 7); //0 is Sunday
+}
+int NTPClient::getHours() const {
+  return ((this->getEpochTime()  % 86400L) / 3600);
+}
+int NTPClient::getMinutes() const {
+  return ((this->getEpochTime() % 3600) / 60);
+}
+int NTPClient::getSeconds() const {
+  return (this->getEpochTime() % 60);
+}
+
+String NTPClient::getFormattedTime() const {
+  unsigned long rawTime = this->getEpochTime();
+  unsigned long hours = (rawTime % 86400L) / 3600;
+  String hoursStr = hours < 10 ? "0" + String(hours) : String(hours);
+
+  unsigned long minutes = (rawTime % 3600) / 60;
+  String minuteStr = minutes < 10 ? "0" + String(minutes) : String(minutes);
+
+  unsigned long seconds = rawTime % 60;
+  String secondStr = seconds < 10 ? "0" + String(seconds) : String(seconds);
+
+  return hoursStr + ":" + minuteStr + ":" + secondStr;
+}
+
+void NTPClient::end() {
+  this->_udp->stop();
+
+  this->_udpSetup = false;
+}
+
+void NTPClient::setTimeOffset(int timeOffset) {
+  this->_timeOffset     = timeOffset;
+}
+
+void NTPClient::setUpdateInterval(unsigned long updateInterval) {
+  this->_updateInterval = updateInterval;
+}
+
+void NTPClient::setPoolServerName(const char* poolServerName) {
+    this->_poolServerName = poolServerName;
+}
+
+void NTPClient::sendNTPPacket() {
+  // set all bytes in the buffer to 0
+  memset(this->_packetBuffer, 0, NTP_PACKET_SIZE);
+  // Initialize values needed to form NTP request
+  // (see URL above for details on the packets)
+  this->_packetBuffer[0] = 0b11100011;   // LI, Version, Mode
+  this->_packetBuffer[1] = 0;     // Stratum, or type of clock
+  this->_packetBuffer[2] = 6;     // Polling Interval
+  this->_packetBuffer[3] = 0xEC;  // Peer Clock Precision
+  // 8 bytes of zero for Root Delay & Root Dispersion
+  this->_packetBuffer[12]  = 49;
+  this->_packetBuffer[13]  = 0x4E;
+  this->_packetBuffer[14]  = 49;
+  this->_packetBuffer[15]  = 52;
+
+  // all NTP fields have been given values, now
+  // you can send a packet requesting a timestamp:
+  this->_udp->beginPacket(this->_poolServerName, 123); //NTP requests are to port 123
+  this->_udp->write(this->_packetBuffer, NTP_PACKET_SIZE);
+  this->_udp->endPacket();
+}

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "Arduino.h"
+
+#include <Udp.h>
+
+#define SEVENZYYEARS 2208988800UL
+#define NTP_PACKET_SIZE 48
+#define NTP_DEFAULT_LOCAL_PORT 1337
+
+class NTPClient {
+  private:
+    UDP*          _udp;
+    bool          _udpSetup       = false;
+
+    const char*   _poolServerName = "pool.ntp.org"; // Default time server
+    int           _port           = NTP_DEFAULT_LOCAL_PORT;
+    long          _timeOffset     = 0;
+
+    unsigned long _updateInterval = 60000;  // In ms
+
+    unsigned long _currentEpoc    = 0;      // In s
+    unsigned long _lastUpdate     = 0;      // In ms
+
+    byte          _packetBuffer[NTP_PACKET_SIZE];
+
+    void          sendNTPPacket();
+
+  public:
+    NTPClient(UDP& udp);
+    NTPClient(UDP& udp, long timeOffset);
+    NTPClient(UDP& udp, const char* poolServerName);
+    NTPClient(UDP& udp, const char* poolServerName, long timeOffset);
+    NTPClient(UDP& udp, const char* poolServerName, long timeOffset, unsigned long updateInterval);
+
+    /**
+     * Set time server name
+     *
+     * @param poolServerName
+     */
+    void setPoolServerName(const char* poolServerName);
+
+    /**
+     * Starts the underlying UDP client with the default local port
+     */
+    void begin();
+
+    /**
+     * Starts the underlying UDP client with the specified local port
+     */
+    void begin(int port);
+
+    /**
+     * This should be called in the main loop of your application. By default an update from the NTP Server is only
+     * made every 60 seconds. This can be configured in the NTPClient constructor.
+     *
+     * @return true on success, false on failure
+     */
+    bool update();
+
+    /**
+     * This will force the update from the NTP Server.
+     *
+     * @return true on success, false on failure
+     */
+    bool forceUpdate();
+
+    int getDay() const;
+    int getHours() const;
+    int getMinutes() const;
+    int getSeconds() const;
+
+    /**
+     * Changes the time offset. Useful for changing timezones dynamically
+     */
+    void setTimeOffset(int timeOffset);
+
+    /**
+     * Set the update interval to another frequency. E.g. useful when the
+     * timeOffset should not be set in the constructor
+     */
+    void setUpdateInterval(unsigned long updateInterval);
+
+    /**
+     * @return time formatted like `hh:mm:ss`
+     */
+    String getFormattedTime() const;
+
+    /**
+     * @return time in seconds since Jan. 1, 1970
+     */
+    unsigned long getEpochTime() const;
+
+    /**
+     * Stops the underlying UDP client
+     */
+    void end();
+};

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -172,9 +172,13 @@ public:
   static void reboot_dev();   // reboot the microcontroller
   static void begin();        // initialization, must call this function before calling other functions
   static byte start_network();  // initialize network with the given mac and port
+  static byte start_ether();  // initialize ethernet with the given mac and port
 #if defined(ARDUINO)
   static bool read_hardware_mac();  // read hardware mac address
 #endif
+  #ifdef ESP8266_ETHERNET
+  static void get_hardware_mac();
+  #endif
   static time_t now_tz();
   // -- station names and attributes
   static void get_station_name(byte sid, char buf[]); // get station name

--- a/defines.h
+++ b/defines.h
@@ -24,6 +24,8 @@
 #ifndef _DEFINES_H
 #define _DEFINES_H
 
+#define ESP8266_ETHERNET
+
 typedef unsigned char byte;
 typedef unsigned long ulong;
 
@@ -376,6 +378,8 @@ typedef enum {
     #define PIN_CURR_SENSE    A0
     #define PIN_FREE_LIST     {} // no free GPIO pin at the moment
     #define ETHER_BUFFER_SIZE   4096
+
+    #define PIN_ETHER_CS       16   // Ethernet controller chip select pin, the CS (chip select pin) is 16 on OS 3.2.
 
     /* To accommodate different OS30 versions, we use software defines pins */ 
     extern byte PIN_BUTTON_1;

--- a/make.lin30
+++ b/make.lin30
@@ -6,9 +6,11 @@ LIBS = .\
   $(ESP_LIBS)/ESP8266mDNS \
   $(ESP_LIBS)/SSD1306 \
   $(ESP_LIBS)/rc-switch \
+  $(ESP_LIBS)/SPI \
+  $(ESP_LIBS)/UIPEthernet \
 
-ESP_ROOT = $(HOME)/esp8266_2.4/
-BUILD_ROOT = /tmp/$(MAIN_NAME)
+ESP_ROOT = /data/esp8266_2.4/
+BUILD_ROOT = ./bin/$(MAIN_NAME)
 
 UPLOAD_SPEED = 230400
 UPLOAD_VERB = -v

--- a/tcpip.cpp
+++ b/tcpip.cpp
@@ -11,7 +11,7 @@
 //
 // 2010-05-20 <jc@wippler.nl>
 
-#ifndef ESP8266
+#if !defined(ESP8266) || defined(ESP8266_ETHERNET)
 
 #include "EtherCard.h"
 #include "net.h"


### PR DESCRIPTION
Support for Ethernet Module
Everything new implementation is marked with #ifdef ESP8266_ETHERNET
Only testet with OpenSprinker AC 3.2 , no PI, no linux, no older versions.
To compile you need the UIPEthernet package from here:
https://github.com/UIPEthernet/UIPEthernet
and modify the utility/Enc28J60Network.h file line 129:

#if defined(ESP8266)
  #define ENC28J60_CONTROL_CS   16 // ray: modified to match OS3.2
#endif
