### PR TITLE
Add systemd service if applicable for autostart

### DIFF
--- a/OpenSprinkler.systemd
+++ b/OpenSprinkler.systemd
@@ -1,0 +1,10 @@
+[Unit]
+Description=OpenSprinkler
+
+[Service]
+ExecStart=__OpenSprinkler_Path__/OpenSprinkler
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
More recent versions of Raspbian use `systemd` to manage application starts.
* Add `OpenSprinkler.systemd` - a `systemd` service template for OpenSprinkler
* Update `build.sh` to install the `systemd` service if appropriate.

NOTE: The check for the directory `/run/systemd/system` may not be foolproof across distros but is a good enough check for the Raspberry Pi and Raspbian IMO.