### PR TITLE
Add MQTT notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ wtopts.txt
 testmode.h
 build-1284/*
 .vscode
+.pio

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ wtopts.txt
 *.sh
 testmode.h
 build-1284/*
+.vscode

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -542,6 +542,18 @@ byte OpenSprinkler::start_ether() {
 	return 1;
 }
 
+bool OpenSprinkler::network_connected(void) {
+#if defined (ESP8266)
+	if(m_server) {
+		return (Ethernet.linkStatus()==LinkON);
+	} else {
+		return (get_wifi_mode()==WIFI_MODE_STA && WiFi.status()==WL_CONNECTED && state==OS_STATE_CONNECTED);
+	}
+#else
+	return (Ethernet.linkStatus()==LinkON);
+#endif
+}
+
 /** Reboot controller */
 void OpenSprinkler::reboot_dev(uint8_t cause) {
 	lcd_print_line_clear_pgm(PSTR("Rebooting..."), 0);
@@ -575,6 +587,10 @@ byte OpenSprinkler::start_network() {
 
 	m_server = new EthernetServer(port);
 	return m_server->begin();
+}
+
+bool OpenSprinkler::network_connected(void) {
+	return true;
 }
 
 /** Reboot controller */

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -29,6 +29,7 @@
 #include "utils.h"
 #include "gpio.h"
 #include "images.h"
+#include "mqtt.h"
 
 #if defined(ARDUINO) // headers for ESP8266
 	#include <Arduino.h>
@@ -54,9 +55,6 @@
 	#include <netdb.h>	
 	#include <sys/stat.h>  
 	#include "etherport.h"
-	#ifdef MQTT
-		#include <mosquitto.h>
-	#endif
 #endif // end of headers
 
 /** Non-volatile data structure */
@@ -133,6 +131,7 @@ struct ConStatus {
 	byte sensor2:1;						// sensor2 status bit (when set, sensor2 on is detected)
 	byte sensor1_active:1;		// sensor1 active bit (when set, sensor1 is activated)
 	byte sensor2_active:1;		// sensor2 active bit (when set, sensor2 is activated)
+	byte req_mqttsetup:1;			// request setup mqtt
 };
 
 extern const char iopt_json_names[];
@@ -155,7 +154,7 @@ public:
 															// to handle RPi rev. 1
 #endif
 
-	static bool mqtt_enabled;
+	static OSMqtt mqtt;
 
 	static NVConData nvdata;
 	static ConStatus status;
@@ -202,9 +201,6 @@ public:
 	static void begin();				// initialization, must call this function before calling other functions
 	static byte start_network();	// initialize network with the given mac and port
 	static byte start_ether();	// initialize ethernet with the given mac and port	
-
-	static void reset_mqtt();
-	static void mqtt_publish(const char *topic, const char *payload);  // publish mqtt message
 
 #if defined(ARDUINO)
 	static bool load_hardware_mac(byte* buffer, bool wired=false);	// read hardware mac address

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -54,6 +54,9 @@
 	#include <netdb.h>	
 	#include <sys/stat.h>  
 	#include "etherport.h"
+	#ifdef MQTT
+		#include <mosquitto.h>
+	#endif
 #endif // end of headers
 
 /** Non-volatile data structure */
@@ -197,6 +200,8 @@ public:
 	static void begin();				// initialization, must call this function before calling other functions
 	static byte start_network();	// initialize network with the given mac and port
 	static byte start_ether();	// initialize ethernet with the given mac and port	
+	static void mqtt_publish(const char *topic, const char *payload);  // publish mqtt message
+
 #if defined(ARDUINO)
 	static bool load_hardware_mac(byte* buffer, bool wired=false);	// read hardware mac address
 #endif

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -131,7 +131,7 @@ struct ConStatus {
 	byte sensor2:1;						// sensor2 status bit (when set, sensor2 on is detected)
 	byte sensor1_active:1;		// sensor1 active bit (when set, sensor1 is activated)
 	byte sensor2_active:1;		// sensor2 active bit (when set, sensor2 is activated)
-	byte req_mqttsetup:1;			// request setup mqtt
+	byte req_mqtt_restart:1;			// request mqtt restart
 };
 
 extern const char iopt_json_names[];
@@ -201,6 +201,7 @@ public:
 	static void begin();				// initialization, must call this function before calling other functions
 	static byte start_network();	// initialize network with the given mac and port
 	static byte start_ether();	// initialize ethernet with the given mac and port	
+	static bool network_connected();		// check if the network is up
 
 #if defined(ARDUINO)
 	static bool load_hardware_mac(byte* buffer, bool wired=false);	// read hardware mac address

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -155,6 +155,8 @@ public:
 															// to handle RPi rev. 1
 #endif
 
+	static bool mqtt_enabled;
+
 	static NVConData nvdata;
 	static ConStatus status;
 	static ConStatus old_status;
@@ -200,6 +202,8 @@ public:
 	static void begin();				// initialization, must call this function before calling other functions
 	static byte start_network();	// initialize network with the given mac and port
 	static byte start_ether();	// initialize ethernet with the given mac and port	
+
+	static void reset_mqtt();
 	static void mqtt_publish(const char *topic, const char *payload);  // publish mqtt message
 
 #if defined(ARDUINO)

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ if [ "$1" == "demo" ]; then
 elif [ "$1" == "osbo" ]; then
 	g++ -o OpenSprinkler -DOSBO main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp -lpthread
 else
-	g++ -o OpenSprinkler -DOSPI main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp -lpthread
+	g++ -o OpenSprinkler -DOSPI -DMQTT main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp -lpthread -lmosquitto
 fi
 
 if [ ! "$SILENT" = true ] && [ -f OpenSprinkler.launch ] && [ ! -f /etc/init.d/OpenSprinkler.sh ]; then

--- a/build.sh
+++ b/build.sh
@@ -11,11 +11,11 @@ done
 echo "Building OpenSprinkler..."
 
 if [ "$1" == "demo" ]; then
-	g++ -o OpenSprinkler -DDEMO -m32 main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp -lpthread
+	g++ -o OpenSprinkler -DDEMO -m32 main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread
 elif [ "$1" == "osbo" ]; then
-	g++ -o OpenSprinkler -DOSBO main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp -lpthread
+	g++ -o OpenSprinkler -DOSBO main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread
 else
-	g++ -o OpenSprinkler -DOSPI -DMQTT main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp -lpthread -lmosquitto
+	g++ -o OpenSprinkler -DOSPI main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread -lmosquitto
 fi
 
 if [ ! "$SILENT" = true ] && [ -f OpenSprinkler.launch ] && [ ! -f /etc/init.d/OpenSprinkler.sh ]; then

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ done
 echo "Building OpenSprinkler..."
 
 if [ "$1" == "demo" ]; then
-	g++ -o OpenSprinkler -DDEMO -m32 main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread
+	g++ -o OpenSprinkler -DDEMO -m32 main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread -lmosquitto
 elif [ "$1" == "osbo" ]; then
 	g++ -o OpenSprinkler -DOSBO main.cpp OpenSprinkler.cpp program.cpp server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread
 else

--- a/defines.h
+++ b/defines.h
@@ -142,8 +142,6 @@ typedef unsigned long ulong;
 #define DEFAULT_WEATHER_URL       "weather.opensprinkler.com"
 #define DEFAULT_IFTTT_URL         "maker.ifttt.com"
 #define DEFAULT_EMPTY_STRING      ""
-#define DEFAULT_MQTT_HOST         "server"
-#define DEFAULT_MQTT_PORT         1883
 
 /** Macro define of each option
   * Refer to OpenSprinkler.cpp for details on each option
@@ -199,7 +197,6 @@ enum {
 	IOPT_DNS_IP4,
 	IOPT_SPE_AUTO_REFRESH,
 	IOPT_IFTTT_ENABLE,
-    IOPT_MQTT_ENABLE,
 	IOPT_SENSOR1_TYPE,
 	IOPT_SENSOR1_OPTION,	
 	IOPT_SENSOR2_TYPE,
@@ -226,9 +223,9 @@ enum {
 	SOPT_IFTTT_KEY,
 	SOPT_STA_SSID,
 	SOPT_STA_PASS,
+	SOPT_MQTT_OPTS,
 	//SOPT_WEATHER_KEY,
 	//SOPT_AP_PASS,
-	//SOPT_MQTT_IP,
 	NUM_SOPTS	// total number of string options
 };
 

--- a/defines.h
+++ b/defines.h
@@ -420,18 +420,12 @@ enum {
 		#define DEBUG_BEGIN(x)   {Serial.begin(x);}
 		#define DEBUG_PRINT(x)   {Serial.print(x);}
 		#define DEBUG_PRINTLN(x) {Serial.println(x);}
-		#define DEBUG_PRINTF(msg, ...)	{Serial.printf(msg, ##__VA_ARGS__);}
-		#define DEBUG_LOGF(msg, ...)	{time_t t = os.now_tz(); Serial.printf("%02d-%02d-%02d %02d:%02d:%02d - ", year(t), month(t), day(t), hour(t), minute(t), second(t)); Serial.printf(msg, ##__VA_ARGS__);}
 	#else
 		#include <stdio.h>
-		#include <time.h>
 		#define DEBUG_BEGIN(x)          {}  /** Serial debug functions */
 		inline  void DEBUG_PRINT(int x) {printf("%d", x);}
 		inline  void DEBUG_PRINT(const char*s) {printf("%s", s);}
 		#define DEBUG_PRINTLN(x)        {DEBUG_PRINT(x);printf("\n");}
-		#define DEBUG_PRINTF(msg, ...)	{printf(msg, ##__VA_ARGS__);}
-		#define DEBUG_TIMESTAMP()		{char tstr[21]; time_t t = time(NULL); struct tm *tm = localtime(&t); strftime(tstr, 21, "%y-%m-%d %H:%M:%S - ", tm);printf("%s", tstr);}
-		#define DEBUG_LOGF(msg, ...)	{DEBUG_TIMESTAMP(); printf(msg, ##__VA_ARGS__);}
 	#endif
   
 #else
@@ -439,8 +433,6 @@ enum {
 	#define DEBUG_BEGIN(x)   {}
 	#define DEBUG_PRINT(x)   {}
 	#define DEBUG_PRINTLN(x) {}
-	#define DEBUG_PRINTF(msg, ...)  {}
-	#define DEBUG_LOGF(msg, ...)    {}
 
 #endif
   

--- a/defines.h
+++ b/defines.h
@@ -66,15 +66,16 @@ typedef unsigned long ulong;
 #define STN_TYPE_HTTP        0x04	// HTTP station
 #define STN_TYPE_OTHER       0xFF
 
-/** IFTTT macro defines */
-#define IFTTT_PROGRAM_SCHED   0x01
-#define IFTTT_SENSOR1         0x02
-#define IFTTT_FLOWSENSOR      0x04
-#define IFTTT_WEATHER_UPDATE  0x08
-#define IFTTT_REBOOT          0x10
-#define IFTTT_STATION_RUN     0x20
-#define IFTTT_SENSOR2         0x40
-#define IFTTT_RAINDELAY				0x80
+/** Notification macro defines */
+#define NOTIFY_PROGRAM_SCHED   0x0001
+#define NOTIFY_SENSOR1         0x0002
+#define NOTIFY_FLOWSENSOR      0x0004
+#define NOTIFY_WEATHER_UPDATE  0x0008
+#define NOTIFY_REBOOT          0x0010
+#define NOTIFY_STATION_OFF     0x0020
+#define NOTIFY_SENSOR2         0x0040
+#define NOTIFY_RAINDELAY       0x0080
+#define NOTIFY_STATION_ON      0x0100
 
 /** HTTP request macro defines */
 #define HTTP_RQT_SUCCESS			 0
@@ -141,6 +142,8 @@ typedef unsigned long ulong;
 #define DEFAULT_WEATHER_URL       "weather.opensprinkler.com"
 #define DEFAULT_IFTTT_URL         "maker.ifttt.com"
 #define DEFAULT_EMPTY_STRING      ""
+#define DEFAULT_MQTT_HOST         "server"
+#define DEFAULT_MQTT_PORT         1883
 
 /** Macro define of each option
   * Refer to OpenSprinkler.cpp for details on each option
@@ -196,6 +199,7 @@ enum {
 	IOPT_DNS_IP4,
 	IOPT_SPE_AUTO_REFRESH,
 	IOPT_IFTTT_ENABLE,
+    IOPT_MQTT_ENABLE,
 	IOPT_SENSOR1_TYPE,
 	IOPT_SENSOR1_OPTION,	
 	IOPT_SENSOR2_TYPE,
@@ -448,6 +452,7 @@ enum {
 	#define F(x)				 x
 	#define strcat_P     strcat
 	#define strcpy_P     strcpy
+	#define sprintf_P    sprintf
 	#include<string>
 	#define String       string
 	using namespace std;

--- a/defines.h
+++ b/defines.h
@@ -420,12 +420,18 @@ enum {
 		#define DEBUG_BEGIN(x)   {Serial.begin(x);}
 		#define DEBUG_PRINT(x)   {Serial.print(x);}
 		#define DEBUG_PRINTLN(x) {Serial.println(x);}
+		#define DEBUG_PRINTF(msg, ...)	{Serial.printf(msg, ##__VA_ARGS__);}
+		#define DEBUG_LOGF(msg, ...)	{time_t t = os.now_tz(); Serial.printf("%02d-%02d-%02d %02d:%02d:%02d - ", year(t), month(t), day(t), hour(t), minute(t), second(t)); Serial.printf(msg, ##__VA_ARGS__);}
 	#else
 		#include <stdio.h>
+		#include <time.h>
 		#define DEBUG_BEGIN(x)          {}  /** Serial debug functions */
 		inline  void DEBUG_PRINT(int x) {printf("%d", x);}
 		inline  void DEBUG_PRINT(const char*s) {printf("%s", s);}
 		#define DEBUG_PRINTLN(x)        {DEBUG_PRINT(x);printf("\n");}
+		#define DEBUG_PRINTF(msg, ...)	{printf(msg, ##__VA_ARGS__);}
+		#define DEBUG_TIMESTAMP()		{char tstr[21]; time_t t = time(NULL); struct tm *tm = localtime(&t); strftime(tstr, 21, "%y-%m-%d %H:%M:%S - ", tm);printf("%s", tstr);}
+		#define DEBUG_LOGF(msg, ...)	{DEBUG_TIMESTAMP(); printf(msg, ##__VA_ARGS__);}
 	#endif
   
 #else
@@ -433,6 +439,8 @@ enum {
 	#define DEBUG_BEGIN(x)   {}
 	#define DEBUG_PRINT(x)   {}
 	#define DEBUG_PRINTLN(x) {}
+	#define DEBUG_PRINTF(msg, ...)  {}
+	#define DEBUG_LOGF(msg, ...)    {}
 
 #endif
   
@@ -489,5 +497,3 @@ enum {
 #define DISPLAY_MSG_MS      2000  // message display time (milliseconds)
 
 #endif  // _DEFINES_H
-
-

--- a/make.lin32
+++ b/make.lin32
@@ -8,6 +8,7 @@ LIBS = . \
   ~/Arduino/libraries/SSD1306 \
   ~/Arduino/libraries/rc-switch \
   ~/Arduino/libraries/UIPEthernet \
+  ~/Arduino/libraries/PubSubClient \
 
 ESP_ROOT = $(HOME)/esp8266_2.5.2/
 ESPCORE_VERSION = 252

--- a/make.os23
+++ b/make.os23
@@ -6,7 +6,7 @@ BOARD_TAG = 1284
 MCU = atmega1284p
 VARIANT = sanguino
 F_CPU = 16000000L
-ARDUINO_LIBS = UIPEthernet Wire SdFat SPI 
+ARDUINO_LIBS = UIPEthernet Wire SdFat SPI PubSubClient
 MONITOR_PORT = /dev/ttyUSB0
 MONITOR_BAUDRATE = 115200
 include ./Arduino.mk

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -1,0 +1,231 @@
+/* OpenSprinkler Unified (AVR/RPI/BBB/LINUX/ESP8266) Firmware
+ * Copyright (C) 2015 by Ray Wang (ray@opensprinkler.com)
+ *
+ * OpenSprinkler library
+ * Feb 2015 @ OpenSprinkler.com
+ *
+ * This file is part of the OpenSprinkler library
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#if defined(ARDUINO)
+	#include <Arduino.h>
+	#include <UIPEthernet.h>
+	#include <PubSubClient.h>
+	#if MQTT_KEEPALIVE != 60
+		#error Set MQTT_KEEPALIVE to 60 in PubSubClient.h
+	#endif
+#elif defined(OSPI)
+	#include <mosquitto.h>
+	#include <time.h>
+#endif
+
+#include "OpenSprinkler.h"
+#include "mqtt.h"
+
+#define MQTT_MAX_HOST_LEN		50 // Note: App is set to max 50 chars for broker name
+#define MQTT_RECONNECT_DELAY	60 // Minumum of 60 seconds between reconnect attempts
+
+#if defined(ARDUINO)
+	#if defined(ESP8266)
+		WiFiClient wifiClient;
+	#endif
+	EthernetClient ethClient;
+    struct PubSubClient *mqtt_client = NULL;
+#else
+	#if defined(OSPI)
+		#define MQTT_KEEPALIVE 60
+		struct mosquitto *mqtt_client = NULL;
+
+		static void mqtt_connection_cb(struct mosquitto *mqtt_client, void *obj, int rc);
+		static void mqtt_disconnection_cb(struct mosquitto *mqtt_client, void *obj, int rc);
+		static void mqtt_log_cb(struct mosquitto *mqtt_client, void *obj, int level, const char *message);
+	#else	// Do nothing os OSBO and DEMO
+		void * mqtt_client = NULL;
+	#endif
+#endif
+
+extern OpenSprinkler os;
+
+char OSMqtt::_host[MQTT_MAX_HOST_LEN + 1];	// IP or host name of the broker
+int OSMqtt::_port = 1883;					// Port of the broker (default 1883)
+char OSMqtt::_id[16];						// Id to identify the client to the broker
+bool OSMqtt::_enabled = false;				// Flag indicating whether MQTT is enabled
+
+// Create an MQTT instance. Note: on OSPi this also starts the loop thread.
+void OSMqtt::start(void) {
+	DEBUG_LOGF("MQTT Start: ");
+#if defined(ARDUINO)
+	Client * client = NULL;
+	bool wired_mac = false;
+	byte mac[6];
+
+    if (mqtt_client) { delete mqtt_client; mqtt_client = 0; }
+
+	#if defined(ESP8266)
+		if (m_server) client = &ethClient;
+		else client = &wifiClient;
+		wired_mac = (m_server != NULL);
+	#else
+		client = &ethClient;
+		wired_mac = true;
+	#endif
+	mqtt_client = new PubSubClient(*client);
+	os.load_hardware_mac(mac, wired_mac);
+
+	sprintf(_id, "OS-%02X%02X%02X%02X%02X%02X",mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+	DEBUG_PRINTF("Client %s ", _id);
+
+	if (mqtt_client == NULL) {
+		DEBUG_PRINTF("Failed to initialise client\n");
+		return;
+	}
+#elif defined(OSPI)
+	int rc;
+
+	mosquitto_lib_init();
+
+	if (mqtt_client) { mosquitto_destroy(mqtt_client); mqtt_client = NULL; };
+
+	mqtt_client = mosquitto_new(NULL, true, NULL);
+	if (mqtt_client == NULL) {
+		DEBUG_PRINTF("Failed to initialise client\n");
+		return;
+	}
+
+	mosquitto_will_set(mqtt_client, "opensprinkler/availability", strlen("offline"), "offline", 0, true);
+	mosquitto_reconnect_delay_set(mqtt_client, 2, MQTT_RECONNECT_DELAY, true);
+	mosquitto_connect_callback_set(mqtt_client, mqtt_connection_cb);
+	mosquitto_disconnect_callback_set(mqtt_client, mqtt_disconnection_cb);
+	mosquitto_log_callback_set(mqtt_client, mqtt_log_cb);
+#endif
+	DEBUG_PRINTF("Success\n");
+}
+
+#if defined(OSPI)
+// Callback called following a connect attempt. If the connection was successful then an "availability" message is sent.
+static void mqtt_connection_cb(struct mosquitto *mqtt_client, void *obj, int rc) {
+	DEBUG_LOGF("MQTT Connnection: %s\n", mosquitto_strerror(rc));
+	if (rc == MOSQ_ERR_SUCCESS)
+		mosquitto_publish(mqtt_client, NULL, "opensprinkler/availability", strlen("online"), "online", 0, true);
+}
+
+static void mqtt_disconnection_cb(struct mosquitto *mqtt_client, void *obj, int rc) {
+	DEBUG_LOGF("MQTT Disconnection: %s\n", mosquitto_strerror(rc));
+}
+
+static void mqtt_log_cb(struct mosquitto *mqtt_client, void *obj, int level, const char *message){
+	if (level != MOSQ_LOG_DEBUG )
+	DEBUG_LOGF("MQTT Log: %s (%d)\n", message, level);
+}
+
+#endif
+
+bool OSMqtt::enabled(void) { return _enabled; }
+
+// Configure the broker host and port fields and enabled/disable the interface
+// param config pointer to a string containing the JSON configuration settings in the form of "{server:"host_name|IP address", port: 1883, enabled:"0|1"}"
+void OSMqtt::setup(void) {
+	String config = os.sopt_load(SOPT_MQTT_OPTS);
+	if (config.length() == 0) {
+		_enabled = false;
+		DEBUG_LOGF("MQTT Setup: Config (None) Disabled\n");
+	} else {
+		int enable = false;
+		sscanf(config.c_str(), "\"server\":\"%[^\"]\",\"port\":\%d,\"enable\":\%d", _host, &_port, &enable);
+		_enabled = (bool)enable;
+		DEBUG_LOGF("MQTT Setup: Config (%s:%d) %s\n", _host, _port, _enabled ? "Enabled" : "Disabled");
+	}
+
+	if (mqtt_client == NULL) return;
+
+#if defined(ARDUINO)
+	if (mqtt_client->connected()) {
+		mqtt_client->disconnect();
+	}
+
+	if (_enabled) {
+		mqtt_client->setServer(_host, _port);
+		if (mqtt_client->connect(_id, NULL, NULL, "opensprinkler/availability", 0, true, "offline")) {
+			mqtt_client->publish("opensprinkler/availability", "online", true);
+		} else {
+			DEBUG_LOGF("MQTT Setup: Connect Failed (%d)\n", mqtt_client->state());
+		}
+	}
+#elif defined(OSPI)
+	mosquitto_disconnect(mqtt_client);
+
+	if (_enabled) {
+		int rc = mosquitto_connect(mqtt_client, _host, _port, MQTT_KEEPALIVE);
+		if (rc != MOSQ_ERR_SUCCESS) DEBUG_LOGF("MQTT Setup: Connect Failed (%s)\n", mosquitto_strerror(rc));
+	}
+#endif
+}
+
+void OSMqtt::publish(const char *topic, const char *payload) {
+	DEBUG_LOGF("MQTT Publish: %s %s\n", topic, payload);
+	if (mqtt_client == NULL || !_enabled || os.status.network_fails > 0) return;
+
+#if defined (ARDUINO)
+	if (!mqtt_client->publish(topic, payload)) {
+		DEBUG_LOGF("MQTT Publish: Failed (%d)\n", mqtt_client->state());
+	}
+#elif defined(OSPI)
+	int rc = mosquitto_publish(mqtt_client, NULL, topic, strlen(payload), payload, 0, false);
+	if (rc != MOSQ_ERR_SUCCESS) {
+		DEBUG_LOGF("MQTT Publish: Failed (%s)\n", mosquitto_strerror(rc));
+	}
+#endif
+}
+
+// Need to regularly call the loop function to ensure "keep alive" messages are sent to the broker and to reconnect if needed.
+void OSMqtt::loop(void) {
+	static unsigned long last_reconnect_attempt = 0;
+	unsigned long now = millis();
+
+	if (mqtt_client == NULL || !_enabled || os.status.network_fails > 0) return;
+
+#if defined (ARDUINO)
+	static int last_state = 999;
+	if (!mqtt_client->connected() && (now - last_reconnect_attempt >= (unsigned long)MQTT_RECONNECT_DELAY*1000)) {
+		if (mqtt_client->connect(_id, NULL, NULL, "opensprinkler/availability", 0, true, "offline"))
+			mqtt_client->publish("opensprinkler/availability", "online", true);
+		last_reconnect_attempt = millis();
+	}
+
+	mqtt_client->loop();
+
+	if (last_state != mqtt_client->state()) {
+		DEBUG_LOGF("MQTT Loop: Connected %d, State %d\n", mqtt_client->connected(), mqtt_client->state());
+		last_state = mqtt_client->state();
+	}
+
+#elif defined(OSPI)
+	static int last_rc = 999;
+
+	int rc = mosquitto_loop(mqtt_client, 0 , 1);
+	if ((rc == MOSQ_ERR_NO_CONN || rc == MOSQ_ERR_CONN_LOST) && (now - last_reconnect_attempt >= (unsigned long)MQTT_RECONNECT_DELAY*1000)) {
+		rc = mosquitto_reconnect(mqtt_client);
+		DEBUG_LOGF("MQTT Loop: Reconnect Status %s\n", mosquitto_strerror(rc));
+		last_reconnect_attempt = millis();
+	}
+
+	if (last_rc != rc) {
+		DEBUG_LOGF("MQTT Loop: Staus %s\n", mosquitto_strerror(rc));
+		last_rc = rc;
+	}
+#endif
+}

--- a/mqtt.h
+++ b/mqtt.h
@@ -1,0 +1,41 @@
+/* OpenSprinkler Unified (AVR/RPI/BBB/LINUX/ESP8266) Firmware
+ * Copyright (C) 2015 by Ray Wang (ray@opensprinkler.com)
+ *
+ * OpenSprinkler library header file
+ * Feb 2015 @ OpenSprinkler.com
+ *
+ * This file is part of the OpenSprinkler library
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _MQTT_H
+#define _MQTT_H
+
+class OSMqtt {
+private:
+    static bool _enabled;
+    static char _id[];
+    static char _host[];
+    static int _port;
+public:
+    static void start(void);
+    static void setup(void);
+    static bool enabled(void);
+    static void publish(const char *topic, const char *payload);
+    static void loop(void);
+};
+
+#endif	// _MQTT_H

--- a/mqtt.h
+++ b/mqtt.h
@@ -26,14 +26,25 @@
 
 class OSMqtt {
 private:
-    static bool _enabled;
     static char _id[];
     static char _host[];
     static int _port;
+    static bool _enabled;
+
+    // Following routines are platform specific versions of the public interface
+    static int _init(void);
+    static int _connect(void);
+    static int _disconnect(void);
+    static bool _connected(void);
+    static int _publish(const char *topic, const char *payload);
+    static int _loop(void);
+    static const char * _state_string(int state);
 public:
-    static void start(void);
-    static void setup(void);
-    static bool enabled(void);
+    static void init(void);
+    static void init(const char * id);
+    static void begin(void);
+    static void begin(const char * host, int port, bool enable);
+    static bool enabled(void) { return _enabled; };
     static void publish(const char *topic, const char *payload);
     static void loop(void);
 };

--- a/server.cpp
+++ b/server.cpp
@@ -1444,11 +1444,11 @@ void server_change_options()
 	if(findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("mqtt"), true, &keyfound)) {
 		urlDecode(tmp_buffer);
 		os.sopt_save(SOPT_MQTT_OPTS, tmp_buffer);
-		os.status.req_mqttsetup = 1;
+		os.status.req_mqtt_restart = true;
 	} else if (keyfound) {
 		tmp_buffer[0]=0;
 		os.sopt_save(SOPT_MQTT_OPTS, tmp_buffer);
-		os.status.req_mqttsetup = 1;
+		os.status.req_mqtt_restart = true;
 	}
 
 	/*

--- a/server.cpp
+++ b/server.cpp
@@ -25,6 +25,7 @@
 #include "program.h"
 #include "server.h"
 #include "weather.h"
+#include "mqtt.h"
 
 // External variables defined in main ion file
 #if defined(ARDUINO)
@@ -1443,11 +1444,11 @@ void server_change_options()
 	if(findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("mqtt"), true, &keyfound)) {
 		urlDecode(tmp_buffer);
 		os.sopt_save(SOPT_MQTT_OPTS, tmp_buffer);
-		os.reset_mqtt();
+		os.status.req_mqttsetup = 1;
 	} else if (keyfound) {
 		tmp_buffer[0]=0;
 		os.sopt_save(SOPT_MQTT_OPTS, tmp_buffer);
-		os.reset_mqtt();
+		os.status.req_mqttsetup = 1;
 	}
 
 	/*
@@ -2307,5 +2308,3 @@ ulong getNtpTime()
 	return 0;
 }
 #endif
-
-

--- a/server.cpp
+++ b/server.cpp
@@ -1138,12 +1138,13 @@ void server_json_controller_main() {
 	bfill.emit_p(PSTR("\"RSSI\":$D,"), (int16_t)WiFi.RSSI());
 #endif
 
-	bfill.emit_p(PSTR("\"loc\":\"$O\",\"jsp\":\"$O\",\"wsp\":\"$O\",\"wto\":{$O},\"ifkey\":\"$O\",\"wtdata\":$S,\"wterr\":$D,"),
+	bfill.emit_p(PSTR("\"loc\":\"$O\",\"jsp\":\"$O\",\"wsp\":\"$O\",\"wto\":{$O},\"ifkey\":\"$O\",\"mqtt\":{$O},\"wtdata\":$S,\"wterr\":$D,"),
 							 SOPT_LOCATION,
 							 SOPT_JAVASCRIPTURL,
 							 SOPT_WEATHERURL,
 							 SOPT_WEATHER_OPTS,
 							 SOPT_IFTTT_KEY,
+							 SOPT_MQTT_OPTS,
 							 strlen(wt_rawData)==0?"{}":wt_rawData,
 							 wt_errCode);
 
@@ -1438,6 +1439,17 @@ void server_change_options()
 		os.sopt_save(SOPT_IFTTT_KEY, tmp_buffer);
 	}
 	
+	keyfound = 0;
+	if(findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("mqtt"), true, &keyfound)) {
+		urlDecode(tmp_buffer);
+		os.sopt_save(SOPT_MQTT_OPTS, tmp_buffer);
+		os.reset_mqtt();
+	} else if (keyfound) {
+		tmp_buffer[0]=0;
+		os.sopt_save(SOPT_MQTT_OPTS, tmp_buffer);
+		os.reset_mqtt();
+	}
+
 	/*
 	// wtkey is retired
 	if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("wtkey"), true, &keyfound)) {
@@ -1457,15 +1469,6 @@ void server_change_options()
 	} else if (keyfound) {
 		tmp_buffer[0]=0;
 		os.sopt_save(SOPT_BLYNK_TOKEN, tmp_buffer);
-	}
-
-	keyfound = 0;
-	if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("mqtt"), true, &keyfound)) {
-		urlDecode(tmp_buffer);
-		os.sopt_save(SOPT_MQTT_IP, tmp_buffer);
-	} else if (keyfound) {
-		tmp_buffer[0]=0;
-		os.sopt_save(SOPT_MQTT_IP, tmp_buffer);
 	}
 	*/
 

--- a/weather.cpp
+++ b/weather.cpp
@@ -21,6 +21,7 @@
  * <http://www.gnu.org/licenses/>. 
  */
 
+#include <stdlib.h>
 #include "OpenSprinkler.h"
 #include "utils.h"
 #include "server.h"
@@ -182,4 +183,3 @@ void GetWeather() {
 		// if wt_errCode > 0, the call is successful but weather script may return error
 	}
 }
-


### PR DESCRIPTION
Send MQTT messages. This implements this feature https://github.com/OpenSprinkler/OpenSprinkler-Firmware/issues/103
Events can be subscribed (like IFTTT).
Note that this PR does not allow for controlling an OpenSprinkler unit but rather generating notifications when its activity changes. 

Supported platforms: OSPI, OS3.0, OS3.2
On OSPI, it requires libmosquitto.

I also rewrite some IFTTT string message generation to use the standard sprintf instead of non-standard itoa.

This replaces my initial PR: https://github.com/OpenSprinkler/OpenSprinkler-Firmware/pull/102
This replaces enhancement PR done by PeteBa: https://github.com/OpenSprinkler/OpenSprinkler-Firmware/pull/108 Thanks to PetaBa for the review and improvements as well as the implementation for OS3

# OSPI instructions
If anyone wants to try out the PR. I suggest using a new SD card with the latest Raspbian Buster so that you can go back to your original setup when finished trying.

Firstly, ensure you have the right dependencies:
```
pi@raspberrypi:~ $ sudo apt-get update
pi@raspberrypi:~ $ sudo apt-get install git
pi@raspberrypi:~ $ sudo apt-get install libmosquitto-dev
```
Next, clone the OpenSprinkler repository and download the PR branch:
```
pi@raspberrypi:~ $ git clone -b ospi-mqtt https://github.com/jbaudoux/OpenSprinkler-Firmware.git
pi@raspberrypi:~ $ cd OpenSprinkler-Firmware/
```
The PR is meant to be used with an equivalent PR on the App so that you can configure your MQTT server IP and Port address via the UI but if you just want to try this out then you can change line 567 in main.cpp from os.mqtt.begin(); to os.mqtt.begin("server_ip", server_port, 1); where you replace server_ip with the ip address of your MQTT Broker and server_port with the port number (usually 1883). Note that the "1" is needed to set mqtt active.

Then build and run:
```
sudo ./build.sh
sudo .OpenSprinkler
```
You should see MQTT messages arrive in your broker when you turn stations on/off. let me know if you have any issues.

# OS3.x limitations
The connection to the MQTT broker in this implementation is not asynchronous. This is because WiFi and Wired connection is supported and current arduino core doesn't support yet native wired connection (note there is a wip on core for esp8266: https://github.com/esp8266/Arduino/pull/6680) This requires to have a reliable connection to your MQTT broker otherwise your OS system could hang trying to reconnect until timeout.