### PR TITLE
Add Disable RTC option and detection

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -161,6 +161,7 @@ const char iopt_json_names[] PROGMEM =
 	"subn4"
 	"wimod"
 	"reset"
+	"nortc"
 	;
 
 // for String options
@@ -245,7 +246,8 @@ const char iopt_prompts[] PROGMEM =
 	"Subnet mask3:   "
 	"Subnet mask4:   "
 	"WiFi mode?      "
-	"Factory reset?  ";
+	"Factory reset?  "
+	"Disable RTC?    ";
 	
 // string options do not have prompts 
 
@@ -314,6 +316,7 @@ const byte iopt_max[] PROGMEM = {
 	255,
 	255,
 	255,
+	1,
 	1
 };
 
@@ -389,7 +392,8 @@ byte OpenSprinkler::iopts[] = {
 	255,// subnet mask 3
 	0,
 	WIFI_MODE_AP, // wifi mode
-	0		// reset
+	0,		// reset
+	0		// RTC disable
 };
 
 /** String option values (stored in RAM) */

--- a/defines.h
+++ b/defines.h
@@ -210,6 +210,7 @@ enum {
 	IOPT_SUBNET_MASK4,
 	IOPT_WIFI_MODE, //ro
 	IOPT_RESET,     //ro
+	IOTS_RTC_DISABLE,
 	NUM_IOPTS // total number of integer options
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -297,9 +297,11 @@ void do_setup() {
 
 	pd.init();						// ProgramData init
 
-	setSyncInterval(RTC_SYNC_INTERVAL);  // RTC sync interval
-	// if rtc exists, sets it as time sync source
-	setSyncProvider(RTC.get);
+	if (!os.iopts[IOTS_RTC_DISABLE] && RTC.detect()) {
+		setSyncInterval(RTC_SYNC_INTERVAL);  // RTC sync interval
+		// if rtc exists, sets it as time sync source
+		setSyncProvider(RTC.get);
+	}
 	os.lcd_print_time(os.now_tz());  // display time to LCD
 	os.powerup_lasttime = os.now_tz();
 	


### PR DESCRIPTION
As discussed [here](https://opensprinkler.com/forums/topic/wrong-dates-with-weatherunderground-api/#post-65094)
Not fully tested (RTC.detect() works, the rest is a guess, and on my hardware, RTC.detect returns false)
@rayshobby am I headed in the right direction?  Is a separate PR needed for the UI repo?