### PR TITLE
Prevent use of the old bad default NTP server.

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -1994,6 +1994,17 @@ void OpenSprinkler::iopts_load() {
 	status.enabled = iopts[IOPT_DEVICE_ENABLE];
 	iopts[IOPT_FW_VERSION] = OS_FW_VERSION;
 	iopts[IOPT_FW_MINOR] = OS_FW_MINOR;
+        /* Reject the former default 50.97.210.169 NTP IP address as
+         * it no longer works, yet is carried on by people's saved
+         * configs when they upgrade from older versions.
+         * IOPT_NTP_IP1 = 0 leads to the new good default behavior. */
+        if (iopts[IOPT_NTP_IP1] == 50 && iopts[IOPT_NTP_IP2] == 97 &&
+            iopts[IOPT_NTP_IP3] == 210 && iopts[IOPT_NTP_IP4] == 169) {
+            iopts[IOPT_NTP_IP1] = 0;
+            iopts[IOPT_NTP_IP2] = 0;
+            iopts[IOPT_NTP_IP3] = 0;
+            iopts[IOPT_NTP_IP4] = 0;
+        }
 }
 
 /** Save integer options to file */


### PR DESCRIPTION
This prevents the use of the old bad default 50.97.210.169 NTP server by scrubbing that value at config load time.

Why? https://opensprinkler.com/forums/topic/wrong-time-on-the-unit/ and related threads and support tickets about that problem that don't need to happen. With this code in place in a future release people upgrading from older versions won't experience the problem.

I do not have a system setup to build and test this firmware.  Consider this a proposal for one thing that could save you support issues in the future.  If you want to accept it, you'll need to do the rest.

As this just runs the fixup at config load time, someone could still set it and save it and it'd be active in the running controller until reboot.  Not ideal?  Doing config fixups as their own function that is called at the end of iopts_load() and the beginning of iopts_save() might be nicer and avoids such inconsistency.

This value scrubbing could also be done in the App when saving or restoring a config.  _(I cannot personally make PRs to the app due to its license, AGPLed code is off-limits for me - so that'll be up to someone else)._