### PR TITLE
Dev/ospi15

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -373,9 +373,9 @@ enum {
 	#define PIN_SENSOR1				14
 	#define PIN_SENSOR2				23
 	#define PIN_RFTX          15    // RF transmitter pin
-	#define PIN_BUTTON_1      23    // button 1
-	#define PIN_BUTTON_2      24    // button 2
-	#define PIN_BUTTON_3      25    // button 3
+	//#define PIN_BUTTON_1      23    // button 1
+	//#define PIN_BUTTON_2      24    // button 2
+	//#define PIN_BUTTON_3      25    // button 3
 
 	#define PIN_FREE_LIST		{5,6,7,8,9,10,11,12,13,16,18,19,20,21,23,24,25,26}  // free GPIO pins
 	#define ETHER_BUFFER_SIZE   16384

--- a/gpio.cpp
+++ b/gpio.cpp
@@ -236,6 +236,21 @@ static byte GPIOSetEdge(int pin, const char *edge) {
 
 /** Set pin mode, in or out */
 void pinMode(int pin, byte mode) {
+#if defined(OSPI)
+	char cmd[BUFFER_MAX];
+	switch(mode) {
+		case INPUT:
+			snprintf(cmd, BUFFER_MAX, "gpio -g mode %d in", pin);
+		break;
+		case OUTPUT:
+			snprintf(cmd, BUFFER_MAX, "gpio -g mode %d out", pin);
+		break;
+		case INPUT_PULLUP:
+			snprintf(cmd, BUFFER_MAX, "gpio -g mode %d in; gpio -g mode %d up", pin);
+		break;
+	}
+	system(cmd);
+#else
 	static const char dir_str[]  = "in\0out";
 
 	char path[BUFFER_MAX];
@@ -260,6 +275,7 @@ void pinMode(int pin, byte mode) {
 	}
 
 	close(fd);
+#endif
 	return;
 }
 

--- a/gpio.h
+++ b/gpio.h
@@ -124,7 +124,13 @@ byte digitalReadExt(byte pin);
 #include "defines.h"
 #define OUTPUT 0
 #define INPUT  1
-#define INPUT_PULLUP 1
+
+#if defined(OSPI)
+#define INPUT_PULLUP 2
+#else
+#define INPUT_PULLUP INPUT
+#endif
+
 #define HIGH	 1
 #define LOW		 0
 

--- a/server.cpp
+++ b/server.cpp
@@ -971,8 +971,8 @@ void server_json_options_main() {
 				continue;
 		#endif
 		
-		#if !defined(ESP8266)
-		// so far only OS3.x has sensor2
+		#if !(defined(ESP8266) || defined(PIN_SENSOR2))
+		// only OS 3.x or controllers that have PIN_SENSOR2 defined support sensor 2 options
 		if (oid==IOPT_SENSOR2_TYPE || oid==IOPT_SENSOR2_OPTION || oid==IOPT_SENSOR2_ON_DELAY || oid==IOPT_SENSOR2_OFF_DELAY)
 			continue;
 		#endif


### PR DESCRIPTION
Adds second sensor support for OSPi 1.5. Sensor pins now use internal pull-up (no longer rely on external pull-up resistors).