### PR TITLE
Mqtt api

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -24,7 +24,7 @@
 #ifndef _DEFINES_H
 #define _DEFINES_H
 
-//#define ENABLE_DEBUG  // enable serial debug
+// #define ENABLE_DEBUG  // enable serial debug
 
 typedef unsigned char byte;
 typedef unsigned long ulong;

--- a/main.cpp
+++ b/main.cpp
@@ -1307,7 +1307,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 
 			if (os.mqtt.enabled()) {
 				sprintf_P(topic, PSTR("opensprinkler/station/%d"), lval);
-				strcpy_P(payload, PSTR("{\"state\":1}"));
+				sprintf_P(payload, PSTR("{\"state %d\":1}"), lval);
 			}
 			break;
 
@@ -1316,9 +1316,9 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 			if (os.mqtt.enabled()) {
 				sprintf_P(topic, PSTR("opensprinkler/station/%d"), lval);
 				if (os.iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_FLOW) {
-					sprintf_P(payload, PSTR("{\"state\":0,\"duration\":%d,\"flow\":%d.%02d}"), (int)fval, (int)flow_last_gpm, (int)(flow_last_gpm*100)%100);
+					sprintf_P(payload, PSTR("{\"state %d\":0,\"duration\":%d,\"flow\":%d.%02d}"), lval, (int)fval, (int)flow_last_gpm, (int)(flow_last_gpm*100)%100);
 				} else {
-					sprintf_P(payload, PSTR("{\"state\":0,\"duration\":%d}"), (int)fval);
+					sprintf_P(payload, PSTR("{\"state %d\":0,\"duration\":%d}"), lval, (int)fval);
 				}
 			}
 			if (ifttt_enabled) {

--- a/main.cpp
+++ b/main.cpp
@@ -570,11 +570,6 @@ void do_loop()
 	}
 	os.mqtt.loop();
 
-	if (curr_time > last_subscribe) {
-		os.mqtt.subscribe();
-		last_subscribe = curr_time + 5;
-	}
-
 	// The main control loop runs once every second
 	if (curr_time != last_time) {
 #if defined(ENABLE_DEBUG)

--- a/main.cpp
+++ b/main.cpp
@@ -404,6 +404,7 @@ void do_loop()
 
 	static ulong last_time = 0;
 	static ulong last_minute = 0;
+	static ulong last_subscribe = 0;
 
 	byte bid, sid, s, pid, qid, bitvalue;
 	ProgramStruct prog;
@@ -568,6 +569,11 @@ void do_loop()
 		os.status.req_mqtt_restart = false;
 	}
 	os.mqtt.loop();
+
+	if (curr_time > last_subscribe) {
+		os.mqtt.subscribe();
+		last_subscribe = curr_time + 5;
+	}
 
 	// The main control loop runs once every second
 	if (curr_time != last_time) {

--- a/main.cpp
+++ b/main.cpp
@@ -404,7 +404,6 @@ void do_loop()
 
 	static ulong last_time = 0;
 	static ulong last_minute = 0;
-	static ulong last_subscribe = 0;
 
 	byte bid, sid, s, pid, qid, bitvalue;
 	ProgramStruct prog;

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -150,7 +150,7 @@ void OSMqtt::begin( const char * host, int port, bool enabled, const char *usern
 	DEBUG_LOGF("MQTT Begin: Config (%s:%d,%s) %s\n", host, port, *username ? "Secure" : "Unsecure", enabled ? "Enabled" : "Disabled");
 
 	strncpy(_host, host, MQTT_MAX_HOST_LEN);
-	_host[MQTT_MAX_ID_LEN] = 0;
+	_host[MQTT_MAX_HOST_LEN] = 0;
 	_port = port;
 	_enabled = enabled;
 
@@ -398,7 +398,7 @@ int OSMqtt::_connect() {
 	// connection is registered before we attempt to send our first NOTIFY_REBOOT notification. 
 	usleep(10000);
 
-	return MQTT_ERROR;
+	return MQTT_SUCCESS;
 }
 
 int OSMqtt::_disconnect(void) {

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -77,15 +77,15 @@ extern char tmp_buffer[];
 #define MQTT_MAX_HOST_LEN		50		// Note: App is set to max 50 chars for broker name
 #define MQTT_MAX_ID_LEN			16		// MQTT Client Id to uniquely reference this unit
 #define MQTT_RECONNECT_DELAY	120		// Minumum of 60 seconds between reconnect attempts
-#define MQTT_MAX_USERNAME_LEN 	50
-#define MQTT_MAX_PASSWORD_LEN 	50
+#define MQTT_MAX_USERNAME_LEN 	32
+#define MQTT_MAX_PASSWORD_LEN 	32
 
 #define MQTT_ROOT_TOPIC			"opensprinkler"
 #define MQTT_AVAILABILITY_TOPIC	MQTT_ROOT_TOPIC "/availability"
 #define MQTT_ONLINE_PAYLOAD		"online"
 #define MQTT_OFFLINE_PAYLOAD	"offline"
 
-#define MQTT_MANUAL_PROG_TOPIC	MQTT_ROOT_TOPIC "/mpgm"
+#define MQTT_MANUAL_PROG_TOPIC	MQTT_ROOT_TOPIC "/mp"
 #define MQTT_MAX_MESSAGE_LEN	60		// pw=(32 bit)&pid=xxx&uwt=xxx 
 
 #define MQTT_SOPT_FORMAT 		"\"server\":\"%[^\"]\",\"port\":\%d,\"enable\":\%d,\"username\":\"%[^\"]\",\"password\":\"%[^\"]\"" 
@@ -147,7 +147,7 @@ void OSMqtt::begin(void) {
 
 // Start the MQTT service and connect to the MQTT broker.
 void OSMqtt::begin( const char * host, int port, bool enabled, const char *username, const char *password) {
-	DEBUG_LOGF("MQTT Begin: Config (%s:%d,%s) %s\n", host, port, *username ? "Secure" : "Unsecure", enabled ? "Enabled" : "Disabled");
+	DEBUG_LOGF("MQTT Begin: Config (%s:%d,%s) %s\n", host, port, *username ? "Auth" : "No-Auth", enabled ? "Enabled" : "Disabled");
 
 	strncpy(_host, host, MQTT_MAX_HOST_LEN);
 	_host[MQTT_MAX_HOST_LEN] = 0;

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -143,8 +143,6 @@ void OSMqtt::begin(void) {
 		sscanf(config.c_str(), MQTT_SOPT_FORMAT, host, &port, &enabled, username, password);
 	}
 
-	printf("password: (%s)\n", password);
-
 	if (strcmp(username, "") == 0) {
 		begin(host, port, (bool)enabled);	
 	} else {

--- a/mqtt.h
+++ b/mqtt.h
@@ -30,22 +30,26 @@ private:
     static char _host[];
     static int _port;
     static bool _enabled;
+    static char _username[];
+    static char _password[];
 
     // Following routines are platform specific versions of the public interface
     static int _init(void);
-    static int _connect(void);
+    static int _connect(const char *username=NULL, const char *password=NULL);
     static int _disconnect(void);
     static bool _connected(void);
     static int _publish(const char *topic, const char *payload);
+    static int _subscribe(void);
     static int _loop(void);
     static const char * _state_string(int state);
 public:
     static void init(void);
-    static void init(const char * id);
+    static void init(const char *id);
     static void begin(void);
-    static void begin(const char * host, int port, bool enable);
+    static void begin(const char *host, int port, bool enable, const char *username=NULL, const char *password=NULL);
     static bool enabled(void) { return _enabled; };
     static void publish(const char *topic, const char *payload);
+    static void subscribe(void);
     static void loop(void);
 };
 

--- a/mqtt.h
+++ b/mqtt.h
@@ -35,11 +35,10 @@ private:
 
     // Following routines are platform specific versions of the public interface
     static int _init(void);
-    static int _connect(const char *username=NULL, const char *password=NULL);
+    static int _connect(void);
     static int _disconnect(void);
     static bool _connected(void);
     static int _publish(const char *topic, const char *payload);
-    static int _subscribe(void);
     static int _loop(void);
     static const char * _state_string(int state);
 public:
@@ -49,7 +48,6 @@ public:
     static void begin(const char *host, int port, bool enable, const char *username=NULL, const char *password=NULL);
     static bool enabled(void) { return _enabled; };
     static void publish(const char *topic, const char *payload);
-    static void subscribe(void);
     static void loop(void);
 };
 

--- a/mqtt.h
+++ b/mqtt.h
@@ -51,4 +51,7 @@ public:
     static void loop(void);
 };
 
+void server_manual_program(void);
+void server_manual_program(char * p);
+
 #endif	// _MQTT_H

--- a/server.cpp
+++ b/server.cpp
@@ -62,6 +62,11 @@
 
 extern char ether_buffer[];
 extern char tmp_buffer[];
+
+// buffer to store incoming messages from mqtt broker
+extern char mqtt_buffer[];
+extern bool from_mqtt;
+
 extern OpenSprinkler os;
 extern ProgramData pd;
 extern ulong flow_count;
@@ -690,14 +695,18 @@ void manual_start_program(byte, byte);
  * uwt: use weather (i.e. watering percentage)
  */
 void server_manual_program() {
-#if defined(ESP8266)
-	char* p = NULL;
-	if(!process_password()) return;
-	if (m_client)
-		p = get_buffer;
-#else
-	char *p = get_buffer;
-#endif
+	char *p = NULL;
+	if (from_mqtt) {
+		p = mqtt_buffer;
+	} else {
+		#if defined(ESP8266)
+			if (!process_password()) return;
+			if (m_client)
+				p = get_buffer;
+		#else
+			p = get_buffer;
+		#endif
+	}
 
 	if (!findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("pid"), true))
 		handle_return(HTML_DATA_MISSING);

--- a/server.cpp
+++ b/server.cpp
@@ -694,19 +694,19 @@ void manual_start_program(byte, byte);
  * pid: program index (0 refers to the first program)
  * uwt: use weather (i.e. watering percentage)
  */
-void server_manual_program() {
-	char *p = NULL;
-	if (from_mqtt) {
-		p = mqtt_buffer;
-	} else {
-		#if defined(ESP8266)
-			if (!process_password()) return;
-			if (m_client)
-				p = get_buffer;
-		#else
+void server_manual_program(void);
+void server_manual_program(char * p);
+
+void server_manual_program(void) {
+	server_manual_program(get_buffer);
+}
+
+void server_manual_program(char * p) {
+	#if defined(ESP8266)
+		if (!process_password()) return;
+		if (m_client)
 			p = get_buffer;
-		#endif
-	}
+	#endif
 
 	if (!findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("pid"), true))
 		handle_return(HTML_DATA_MISSING);

--- a/server.cpp
+++ b/server.cpp
@@ -694,8 +694,6 @@ void manual_start_program(byte, byte);
  * pid: program index (0 refers to the first program)
  * uwt: use weather (i.e. watering percentage)
  */
-void server_manual_program(void);
-void server_manual_program(char * p);
 
 void server_manual_program(void) {
 	server_manual_program(get_buffer);


### PR DESCRIPTION
Added: 

- ability to connect to authenticated mqtt brokers. UI component is available at (https://github.com/OpenSprinkler/OpenSprinkler-App/tree/mqtt-secure). Menu->Integrations->MQTT has a username and a password field. 

- (proof of concept) ability to run a manual program by publishing a command to the broker. The following has been tested using mosquitto: 

  - mosquitto_pub -h hostname -p port -u username -P password -m 'opensprinkler/mpgm' -t 'pid=programnumber&uwt=(0 or 1 use weather for watering percentage)'

- for turning stations on and off, mqtt publishing payloads now contain the number of the appropriate station for better readability (when subscribing to 'opensprinkler/#' for exampe). 
