### PR TITLE
Expose MAC address on rest api

### DIFF
--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -202,10 +202,7 @@ public:
 	static byte start_network();	// initialize network with the given mac and port
 	static byte start_ether();	// initialize ethernet with the given mac and port	
 	static bool network_connected();		// check if the network is up
-
-#if defined(ARDUINO)
 	static bool load_hardware_mac(byte* buffer, bool wired=false);	// read hardware mac address
-#endif
 	static time_t now_tz();
 	// -- station names and attributes
 	static void get_station_data(byte sid, StationData* data); // get station data

--- a/server.cpp
+++ b/server.cpp
@@ -1133,6 +1133,10 @@ void server_json_controller_main() {
 	bfill.emit_p(PSTR("\"RSSI\":$D,"), (int16_t)WiFi.RSSI());
 #endif
 
+	byte mac[6] = {0};
+	os.load_hardware_mac(mac, m_server!=NULL);
+	bfill.emit_p(PSTR("\"mac\":[$D,$D,$D,$D,$D,$D],"), mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
 	bfill.emit_p(PSTR("\"loc\":\"$O\",\"jsp\":\"$O\",\"wsp\":\"$O\",\"wto\":{$O},\"ifkey\":\"$O\",\"mqtt\":{$O},\"wtdata\":$S,\"wterr\":$D,"),
 							 SOPT_LOCATION,
 							 SOPT_JAVASCRIPTURL,

--- a/server.cpp
+++ b/server.cpp
@@ -304,6 +304,11 @@ void send_packet(bool final=false) {
 #endif	
 }
 
+char dec2hexchar(byte dec) {
+	if(dec<10) return '0'+dec;
+	else return 'A'+(dec-10);
+}
+
 #if defined(ESP8266)
 String two_digits(uint8_t x) {
 	return String(x/10) + (x%10);
@@ -390,11 +395,6 @@ void append_key_value(String& html, const char* key, const String& value) {
 	html += "\":\"";
 	html += value;
 	html += "\",";
-}
-
-char dec2hexchar(byte dec) {
-	if(dec<10) return '0'+dec;
-	else return 'A'+(dec-10);
 }
 
 String get_ap_ssid() {
@@ -1135,7 +1135,7 @@ void server_json_controller_main() {
 
 	byte mac[6] = {0};
 	os.load_hardware_mac(mac, m_server!=NULL);
-	bfill.emit_p(PSTR("\"mac\":[$D,$D,$D,$D,$D,$D],"), mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+	bfill.emit_p(PSTR("\"mac\":\"$X:$X:$X:$X:$X:$X\","), mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
 	bfill.emit_p(PSTR("\"loc\":\"$O\",\"jsp\":\"$O\",\"wsp\":\"$O\",\"wto\":{$O},\"ifkey\":\"$O\",\"mqtt\":{$O},\"wtdata\":$S,\"wterr\":$D,"),
 							 SOPT_LOCATION,

--- a/server.h
+++ b/server.h
@@ -28,6 +28,8 @@
 #include <stdarg.h>
 #endif
 
+char dec2hexchar(byte dec);
+
 class BufferFiller {
 	char *start; //!< Pointer to start of buffer
 	char *ptr; //!< Pointer to cursor position
@@ -59,6 +61,12 @@ public:
 			case 'S':
 				strcpy((char*) ptr, va_arg(ap, const char*));
 				break;
+			case 'X': {
+				char d = va_arg(ap, int);
+				*ptr++ = dec2hexchar((d >> 4) & 0x0F);
+				*ptr++ = dec2hexchar(d & 0x0F);
+			}
+				continue;
 			case 'F': {
 				PGM_P s = va_arg(ap, PGM_P);
 				char d;


### PR DESCRIPTION
Hey Ray, hope you are OK with this small PR that exposes MAC address via the rest api.

I have been working with the guys over at Home Assistant on an OpenSprinkler integration. It would be fantastic to combine the info coming from OS with the automation possible in HA. Specifically for things like Leak Detection (i.e. notify if flow is reading when no station is on) and similarly with failed valves (i.e. no flow when station on). The MQTT stuff will help take this even further!

One of the things we really need to make all this work is a unique identifier that stays pretty constant and that we can use to uniquely identify a particular OS unit. The MAC address is the most common identifier used for that purpose. Let me know if any concerns and I can modify as needed.

Addresses issue #124 