### PR TITLE
MQTT: Allow to connect with username and password

### DIFF
--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -245,10 +245,10 @@ int OSMqtt::_init(void) {
 int OSMqtt::_connect(void) {
 	mqtt_client->setServer(_host, _port);
 	boolean state;
-	if (username[0] == '\0')
-		state = mqtt_client->connect(_id, NULL, NULL, MQTT_AVAILABILITY_TOPIC, 0, true, MQTT_OFFLINE_PAYLOAD) {
-	else
+	if (username[0])
 		state = mqtt_client->connect(_id, _username, _password, MQTT_AVAILABILITY_TOPIC, 0, true, MQTT_OFFLINE_PAYLOAD) {
+	else
+		state = mqtt_client->connect(_id, NULL, NULL, MQTT_AVAILABILITY_TOPIC, 0, true, MQTT_OFFLINE_PAYLOAD) {
 	if (state) {
 		mqtt_client->publish(MQTT_AVAILABILITY_TOPIC, MQTT_ONLINE_PAYLOAD, true);
 	} else {
@@ -347,10 +347,13 @@ int OSMqtt::_init(void) {
 }
 
 int OSMqtt::_connect(void) {
-	int rc = mosquitto_username_pw_set(mqtt_client, _username, _password);
-	if (rc != MOSQ_ERR_SUCCESS) {
-		DEBUG_LOGF("MQTT Connect: Connection Failed (%s)\n", mosquitto_strerror(rc));
-		return MQTT_ERROR;
+	int rc;
+	if (username[0]) {
+		rc = mosquitto_username_pw_set(mqtt_client, _username, _password);
+		if (rc != MOSQ_ERR_SUCCESS) {
+			DEBUG_LOGF("MQTT Connect: Connection Failed (%s)\n", mosquitto_strerror(rc));
+			return MQTT_ERROR;
+		}
 	}
 	rc = mosquitto_connect(mqtt_client, _host, _port, MQTT_KEEPALIVE);
 	if (rc != MOSQ_ERR_SUCCESS) {

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -37,7 +37,6 @@
 #else
 	#include <time.h>
 	#include <stdio.h>
-	#include <string.h>
 	#include <mosquitto.h>
 
 	#define MQTT_KEEPALIVE 60
@@ -74,6 +73,7 @@
 #define xstr(s) str(s)
 
 extern OpenSprinkler os;
+extern char tmp_buffer[];
 
 #define MQTT_DEFAULT_PORT		1883	// Default port for MQTT. Can be overwritten through App config
 #define MQTT_MAX_HOST_LEN		50		// Note: App is set to max 50 chars for broker name
@@ -130,10 +130,11 @@ void OSMqtt::begin(void) {
 	int enabled = 0;
 
 	// JSON configuration settings in the form of "{server:"host_name|IP address",port:1883,username:"",password:"",enabled:"0|1"}"
-	String config = os.sopt_load(SOPT_MQTT_OPTS);
-	if (config.length() != 0) {
+	char *config = tmp_buffer;
+	os.sopt_load(SOPT_MQTT_OPTS, config);
+	if (*config != 0) {
 		sscanf(
-			config.c_str(),
+			config,
 			"\"server\":\"%" xstr(MQTT_MAX_HOST_LEN) "[^\"]\",\"port\":\%d,\"username\":\"%" xstr(MQTT_MAX_USERNAME_LEN) "[^\"]\",\"password\":\"%" xstr(MQTT_MAX_PASSWORD_LEN) "[^\"]\",\"enable\":\%d",
 			host, &port, username, password, &enabled
 			);

--- a/mqtt.h
+++ b/mqtt.h
@@ -29,6 +29,8 @@ private:
     static char _id[];
     static char _host[];
     static int _port;
+    static char _username[];
+    static char _password[];
     static bool _enabled;
 
     // Following routines are platform specific versions of the public interface
@@ -43,7 +45,7 @@ public:
     static void init(void);
     static void init(const char * id);
     static void begin(void);
-    static void begin(const char * host, int port, bool enable);
+    static void begin(const char * host, int port, const char * username, const char * password, bool enable);
     static bool enabled(void) { return _enabled; };
     static void publish(const char *topic, const char *payload);
     static void loop(void);


### PR DESCRIPTION
This follows up the several requests in https://github.com/OpenSprinkler/OpenSprinkler-Firmware/pull/113 to support connection to broker with username and password.

Not tested.