### PR TITLE
MQTT: refactor messages for better home assistant integration

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1301,7 +1301,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 
 			if (os.mqtt.enabled()) {
 				sprintf_P(topic, PSTR("opensprinkler/station/%d/state"), lval);
-				itoa(1, payload, 10);
+				strcpy_P(payload, PSTR("{\"state\":\"on\"}"));
 			}
 			break;
 
@@ -1309,15 +1309,10 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 
 			if (os.mqtt.enabled()) {
 				sprintf_P(topic, PSTR("opensprinkler/station/%d/state"), lval);
-				itoa(0, payload, 10);
-				os.mqtt.publish(topic, payload);
-				topic[0] = 0;
-				payload[0] = 0;
-				sprintf_P(topic, PSTR("opensprinkler/station/%d/report"), lval);
 				if (os.iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_FLOW) {
-					sprintf_P(payload, PSTR("{\"duration\":%d,\"flow\":%d.%02d}"), (int)fval, (int)flow_last_gpm, (int)(flow_last_gpm*100)%100);
+					sprintf_P(payload, PSTR("{\"state\":\"off\",\"duration\":%d,\"flow\":%d.%02d}"), (int)fval, (int)flow_last_gpm, (int)(flow_last_gpm*100)%100);
 				} else {
-					sprintf_P(payload, PSTR("{\"duration\":%d}"), (int)fval);
+					sprintf_P(payload, PSTR("{\"state\":\"off\",\"duration\":%d}"), (int)fval);
 				}
 			}
 			if (ifttt_enabled) {
@@ -1374,7 +1369,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 
 			if (os.mqtt.enabled()) {
 				strcpy_P(topic, PSTR("opensprinkler/raindelay/state"));
-				itoa((int)fval, payload, 10);
+				strcpy_P(payload, (int)fval ? PSTR("on") : PSTR("off"));
 			}
 			if (ifttt_enabled) {
 				strcat_P(postval, PSTR("Rain delay "));
@@ -1388,7 +1383,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 			volume = (volume<<8)+os.iopts[IOPT_PULSE_RATE_0];
 			volume = lval*volume;
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/sensor/flow/report"));
+				strcpy_P(topic, PSTR("opensprinkler/sensor/flow/state"));
 				sprintf_P(payload, PSTR("{\"count\":%d,\"volume\":%d.%02d}"), lval, (int)volume/100, (int)volume%100);
 			}
 			if (ifttt_enabled) {
@@ -1416,8 +1411,8 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_REBOOT:
 
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/system/state"));
-				strcpy_P(payload, PSTR("STARTED"));
+				strcpy_P(topic, PSTR("opensprinkler/system/power_state"));
+				strcpy_P(payload, PSTR("on"));
 			}
 			if (ifttt_enabled) {
 				#if defined(ARDUINO)

--- a/main.cpp
+++ b/main.cpp
@@ -1301,7 +1301,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 
 			if (os.mqtt.enabled()) {
 				sprintf_P(topic, PSTR("opensprinkler/station/%d/state"), lval);
-				strcpy_P(payload, PSTR("1"));
+				itoa(1, payload, 10);
 			}
 			break;
 

--- a/main.cpp
+++ b/main.cpp
@@ -1300,19 +1300,24 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case  NOTIFY_STATION_ON:
 
 			if (os.mqtt.enabled()) {
-				sprintf_P(topic, PSTR("opensprinkler/station/%d"), lval);
-				strcpy_P(payload, PSTR("{\"state\":1}"));
+				sprintf_P(topic, PSTR("opensprinkler/station/%d/state"), lval);
+				strcpy_P(payload, PSTR("1"));
 			}
 			break;
 
 		case NOTIFY_STATION_OFF:
 
 			if (os.mqtt.enabled()) {
-				sprintf_P(topic, PSTR("opensprinkler/station/%d"), lval);
+				sprintf_P(topic, PSTR("opensprinkler/station/%d/state"), lval);
+				itoa(0, payload, 10);
+				os.mqtt.publish(topic, payload);
+				topic[0] = 0;
+				payload[0] = 0;
+				sprintf_P(topic, PSTR("opensprinkler/station/%d/report"), lval);
 				if (os.iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_FLOW) {
-					sprintf_P(payload, PSTR("{\"state\":0,\"duration\":%d,\"flow\":%d.%02d}"), (int)fval, (int)flow_last_gpm, (int)(flow_last_gpm*100)%100);
+					sprintf_P(payload, PSTR("{\"duration\":%d,\"flow\":%d.%02d}"), (int)fval, (int)flow_last_gpm, (int)(flow_last_gpm*100)%100);
 				} else {
-					sprintf_P(payload, PSTR("{\"state\":0,\"duration\":%d}"), (int)fval);
+					sprintf_P(payload, PSTR("{\"duration\":%d}"), (int)fval);
 				}
 			}
 			if (ifttt_enabled) {
@@ -1344,8 +1349,8 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_SENSOR1:
 
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/sensor1"));
-				sprintf_P(payload, PSTR("{\"state\":%d}"), (int)fval);
+				strcpy_P(topic, PSTR("opensprinkler/sensor1/state"));
+				itoa((int)fval, payload, 10);
 			}
 			if (ifttt_enabled) {
 				strcat_P(postval, PSTR("Sensor 1 "));
@@ -1356,8 +1361,8 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_SENSOR2:
 
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/sensor2"));
-				sprintf_P(payload, PSTR("{\"state\":%d}"), (int)fval);
+				strcpy_P(topic, PSTR("opensprinkler/sensor2/state"));
+				itoa((int)fval, payload, 10);
 			}
 			if (ifttt_enabled) {
 				strcat_P(postval, PSTR("Sensor 2 "));
@@ -1368,8 +1373,8 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_RAINDELAY:
 
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/raindelay"));
-				sprintf_P(payload, PSTR("{\"state\":%d}"), (int)fval);
+				strcpy_P(topic, PSTR("opensprinkler/raindelay/state"));
+				itoa((int)fval, payload, 10);
 			}
 			if (ifttt_enabled) {
 				strcat_P(postval, PSTR("Rain delay "));
@@ -1383,7 +1388,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 			volume = (volume<<8)+os.iopts[IOPT_PULSE_RATE_0];
 			volume = lval*volume;
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/sensor/flow"));
+				strcpy_P(topic, PSTR("opensprinkler/sensor/flow/report"));
 				sprintf_P(payload, PSTR("{\"count\":%d,\"volume\":%d.%02d}"), lval, (int)volume/100, (int)volume%100);
 			}
 			if (ifttt_enabled) {
@@ -1411,8 +1416,8 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_REBOOT:
 
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/system"));
-				strcpy_P(payload, PSTR("{\"state\":\"started\"}"));
+				strcpy_P(topic, PSTR("opensprinkler/system/state"));
+				strcpy_P(payload, PSTR("STARTED"));
 			}
 			if (ifttt_enabled) {
 				#if defined(ARDUINO)


### PR DESCRIPTION
I wonder if we should not change the way the messages are published to be more close to the several integrations existing in home assistant
https://www.home-assistant.io/integrations/mqtt/

This would allow in the future to also listen to "..../set" topics to receive commands

I know that json can be parsed in home assistant, but as the MQTT feature has not yet been released, it's still the time to ask our self if we should not do this small change to ease the integration. 

Relates to initial issue https://github.com/OpenSprinkler/OpenSprinkler-Firmware/issues/103 and my comment here https://github.com/OpenSprinkler/OpenSprinkler-Firmware/pull/130#issuecomment-640843714

Not tested

Before
--------
- system start
  topic: opensprinkler/system
  payload: {"state":"started"}
- station start
  topic: opensprinkler/station/<id starting at 0>
  payload: {"state":1}
- station stop
  topic: opensprinkler/station/<id starting at 0>
  payload:
    if flow sensor configured: {"state":0,"duration":[integer],"flow":[float]}
    else: {"state":0,"duration":<integer>}
- measured flow
  topic: opensprinkler/sensor/flow
  payload: {"count":[integer],"volume":[float]}
- rain detection
  topic: opensprinkler/sensor/rain
  payload: {"state":0/1}

After
------
- system start
  topic: opensprinkler/system/**power_state**
  payload: **on**
- station start
  topic: opensprinkler/station/<id starting at 0>/state
  payload: **{"state": "on"}** 
- station stop
  topic: opensprinkler/station/<id starting at 0>/state
  payload: 
    if flow sensor configured: **{"state": "off", "duration":[integer],"flow":[float]}**
    else: **{"state": "off", "duration":[integer]}**
- measured flow
  topic: opensprinkler/sensor/flow/state
  payload: {"count":[integer],"volume":[float]}
- rain detection
  topic: opensprinkler/sensor/rain/state
  payload: **"on"|"off"**