### PR TITLE
MQTT support for multiple devices

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1301,7 +1301,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 
 			// todo: add IFTTT support for this event as well
 			if (os.mqtt.enabled()) {
-				sprintf_P(topic, PSTR("opensprinkler/station/%d"), lval);
+				sprintf_P(topic, PSTR("station/%d"), lval);
 				strcpy_P(payload, PSTR("{\"state\":1}"));
 			}
 			break;
@@ -1309,7 +1309,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_STATION_OFF:
 
 			if (os.mqtt.enabled()) {
-				sprintf_P(topic, PSTR("opensprinkler/station/%d"), lval);
+				sprintf_P(topic, PSTR("station/%d"), lval);
 				if (os.iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_FLOW) {
 					sprintf_P(payload, PSTR("{\"state\":0,\"duration\":%d,\"flow\":%d.%02d}"), (int)fval, (int)flow_last_gpm, (int)(flow_last_gpm*100)%100);
 				} else {
@@ -1345,7 +1345,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_SENSOR1:
 
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/sensor1"));
+				strcpy_P(topic, PSTR("sensor1"));
 				sprintf_P(payload, PSTR("{\"state\":%d}"), (int)fval);
 			}
 			if (ifttt_enabled) {
@@ -1357,7 +1357,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_SENSOR2:
 
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/sensor2"));
+				strcpy_P(topic, PSTR("sensor2"));
 				sprintf_P(payload, PSTR("{\"state\":%d}"), (int)fval);
 			}
 			if (ifttt_enabled) {
@@ -1369,7 +1369,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_RAINDELAY:
 
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/raindelay"));
+				strcpy_P(topic, PSTR("raindelay"));
 				sprintf_P(payload, PSTR("{\"state\":%d}"), (int)fval);
 			}
 			if (ifttt_enabled) {
@@ -1384,7 +1384,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 			volume = (volume<<8)+os.iopts[IOPT_PULSE_RATE_0];
 			volume = lval*volume;
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/sensor/flow"));
+				strcpy_P(topic, PSTR("sensor/flow"));
 				sprintf_P(payload, PSTR("{\"count\":%d,\"volume\":%d.%02d}"), lval, (int)volume/100, (int)volume%100);
 			}
 			if (ifttt_enabled) {
@@ -1412,7 +1412,7 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 		case NOTIFY_REBOOT:
 			
 			if (os.mqtt.enabled()) {
-				strcpy_P(topic, PSTR("opensprinkler/system"));
+				strcpy_P(topic, PSTR("system"));
 				strcpy_P(payload, PSTR("{\"state\":\"started\"}"));
 			}
 			if (ifttt_enabled) {

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -47,8 +47,8 @@
 #if defined(ENABLE_DEBUG)
 	#if defined(ARDUINO)
 		#include "TimeLib.h"
-		#define DEBUG_PRINTF(msg, ...)		{char buffer[TMP_BUFFER_SIZE]; sprintf(buffer, msg, ##__VA_ARGS__); Serial.println(buffer);}
-		#define DEBUG_TIMESTAMP(msg, ...)	{time_t t = os.now_tz(); char buffer[TMP_BUFFER_SIZE]; sprintf(buffer, "%02d-%02d-%02d %02d:%02d:%02d - ", year(t), month(t), day(t), hour(t), minute(t), second(t)); Serial.println(buffer);}
+		#define DEBUG_PRINTF(msg, ...)		{char buffer[TMP_BUFFER_SIZE]; sprintf(buffer, msg, ##__VA_ARGS__); Serial.print(buffer);}
+		#define DEBUG_TIMESTAMP(msg, ...)	{time_t t = os.now_tz(); char buffer[TMP_BUFFER_SIZE]; sprintf(buffer, "%02d-%02d-%02d %02d:%02d:%02d - ", year(t), month(t), day(t), hour(t), minute(t), second(t)); Serial.print(buffer);}
 	#else
 		#include <sys/time.h>
 		#define DEBUG_PRINTF(msg, ...)		{printf(msg, ##__VA_ARGS__);}

--- a/mqtt.h
+++ b/mqtt.h
@@ -26,6 +26,8 @@
 
 class OSMqtt {
 private:
+    friend struct _mqtt_callbacks;
+
     static char _id[];
     static char _host[];
     static int _port;
@@ -40,7 +42,11 @@ private:
     static bool _connected(void);
     static int _publish(const char *topic, const char *payload);
     static int _loop(void);
-    static const char * _state_string(int state);
+
+    // Helper functions
+    static const char * _state_to_string(int state);
+    static int _make_full_topic(char * full_topic, const char * topic);
+
 public:
     static void init(void);
     static void init(const char * id);


### PR DESCRIPTION
This adds support for multiple opensprinkler devices using MAC address as the unique client identifier. The topic tree is extended to the form `opensprinkler/OS-MACADDRESS/...` to allow for addressing specific units. I have retained `opensprinkler` as root topic to avoid namespace conflict and to allow for group broadcast in future.

There are some minor code corrections to allow for MQTT usernames without passwords. 