### PR TITLE
make.os23 file did not work on macOS Catalina

### DIFF
--- a/make.os23
+++ b/make.os23
@@ -1,12 +1,14 @@
 OFLAG = -Os
 ARDMK_DIR = .
-ARDUINO_DIR = $(HOME)/arduino-1.8.5
-ALTERNATE_CORE_PATH = $(HOME)/.arduino15/packages/MightyCore/hardware/avr/2.0.5
+#ARDUINO_DIR = $(HOME)/arduino-1.8.5
+#ARDUINO_DIR = $(HOME)/Documents/Arduino/libraries
+#ALTERNATE_CORE_PATH = $(HOME)/.arduino15/packages/MightyCore/hardware/avr/2.0.5
+ALTERNATE_CORE_PATH = $(HOME)/Library/Arduino15/packages/MightyCore/hardware/avr/2.0.5
 BOARD_TAG = 1284
 MCU = atmega1284p
 VARIANT = sanguino
 F_CPU = 16000000L
-ARDUINO_LIBS = UIPEthernet Wire SdFat SPI pubsubclient
+ARDUINO_LIBS = UIPEthernet Wire SdFat SPI PubSubClient
 MONITOR_PORT = /dev/ttyUSB0
 MONITOR_BAUDRATE = 115200
 include ./Arduino.mk

--- a/server.cpp
+++ b/server.cpp
@@ -1867,6 +1867,10 @@ void server_json_debug() {
   (uint16_t)freeHeap());
   bfill.emit_p(PSTR("}"));
   #endif
+
+// debug tmp_buffer
+  bfill.emit_p(PSTR("***tmp_buffer:\"$S\""),tmp_buffer);
+
   handle_return(HTML_OK);
 }
 #endif


### PR DESCRIPTION
Only change worth noting here is the make.os23 file change with the error (?) in the identification of the PubSubClient Arduino library.  Would not compile without correcting the case of the library.

The server.cpp change was added to assist in debugging a situation I was having (precompile, from downloaded firmware) where password would be corrupted nearly daily.  I have not had this problem since compiling my own version and installing on OS 2.3 AC.