### PR TITLE
Fixed refresh of remote stations so they go in order and code now sets correct duration on the remote initially and during refreshes.

### DIFF
--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -166,6 +166,7 @@ public:
 	static byte iopts[]; // integer options
 	static const char*sopts[]; // string options
 	static byte station_bits[];			// station activation bits. each byte corresponds to a board (8 stations)
+	static ulong station_finish[];		// station run finish time. each ulong corresponds to the finish time for that station
 																	// first byte-> master controller, second byte-> ext. board 1, and so on
 	// todo future: the following attribute bytes are for backward compatibility
 	static byte attrib_mas[];
@@ -215,7 +216,7 @@ public:
 	static void attribs_load(); // load and repackage attrib bits (backward compatibility)
 	static uint16_t parse_rfstation_code(RFStationData *data, ulong *on, ulong *off); // parse rf code into on/off/time sections
 	static void switch_rfstation(RFStationData *data, bool turnon);  // switch rf station
-	static void switch_remotestation(RemoteStationData *data, bool turnon); // switch remote station
+	static void switch_remotestation(RemoteStationData *data, bool turnon, ulong duration); // switch remote station
 	static void switch_gpiostation(GPIOStationData *data, bool turnon); // switch gpio station
 	static void switch_httpstation(HTTPStationData *data, bool turnon); // switch http station
 
@@ -247,8 +248,8 @@ public:
 	static int detect_exp();				// detect the number of expansion boards
 	static byte weekday_today();		// returns index of today's weekday (Monday is 0)
 
-	static byte set_station_bit(byte sid, byte value); // set station bit of one station (sid->station index, value->0/1)
-	static void switch_special_station(byte sid, byte value); // swtich special station
+	static byte set_station_bit(byte sid, byte value, ulong finish); // set station bit of one station (sid->station index, value->0/1)
+	static void switch_special_station(byte sid, byte value, ulong duration); // swtich special station
 	static void clear_all_station_bits(); // clear all station bits
 	static void apply_all_station_bits(); // apply all station bits (activate/deactive values)
 


### PR DESCRIPTION
Modified the refresh routine to refresh stations in order so that all stations will be hit and be hit in a predictable order. Modified the calls involved to pass the station termination time when it's triggered so that the lower level routines can use the termination time to calculate duration based on current time and correct time can be set to the remote whether during the initial call or during later refreshes. Duration is stored in a variable that could be modified in the future by a pause routine so that duration is correct when things are unpaused.