### PR TITLE
Make firmware PlatformIO compilable

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -22,7 +22,7 @@
  */
 
 #include "OpenSprinkler.h"
-#include "server.h"
+#include "opensprinkler_server.h"
 #include "gpio.h"
 #include "testmode.h"
 

--- a/main.cpp
+++ b/main.cpp
@@ -26,7 +26,7 @@
 #include "OpenSprinkler.h"
 #include "program.h"
 #include "weather.h"
-#include "server.h"
+#include "opensprinkler_server.h"
 #include "mqtt.h"
 
 #if defined(ARDUINO)

--- a/opensprinkler_server.cpp
+++ b/opensprinkler_server.cpp
@@ -23,7 +23,7 @@
 
 #include "OpenSprinkler.h"
 #include "program.h"
-#include "server.h"
+#include "opensprinkler_server.h"
 #include "weather.h"
 #include "mqtt.h"
 

--- a/opensprinkler_server.h
+++ b/opensprinkler_server.h
@@ -21,12 +21,15 @@
  * <http://www.gnu.org/licenses/>. 
  */
  
-#ifndef _SERVER_H
-#define _SERVER_H
+#ifndef _OPENSPRINKLER_SERVER_H
+#define _OPENSPRINKLER_SERVER_H
 
 #if !defined(ARDUINO)
 #include <stdarg.h>
+#else 
+#include <Arduino.h>
 #endif
+#include <utils.h>
 
 char dec2hexchar(byte dec);
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,27 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+; adapt to the already existing folder structure.
+; usually there's src/ and include/ folders. 
+; redirect them both.
+[platformio]
+src_dir = .
+include_dir = .
+
+[env:d1_mini_lite]
+platform = espressif8266
+board = d1_mini_lite
+framework = arduino
+lib_ldf_mode = deep
+lib_deps =
+     uipethernet/UIPEthernet @ ^2.0.8
+     sui77/rc-switch @ ^2.6.3
+     squix78/ESP8266_SSD1306 @ ^4.1.0
+     knolleary/PubSubClient @ ^2.8

--- a/weather.cpp
+++ b/weather.cpp
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include "OpenSprinkler.h"
 #include "utils.h"
-#include "server.h"
+#include "opensprinkler_server.h"
 #include "weather.h"
 
 extern OpenSprinkler os; // OpenSprinkler object


### PR DESCRIPTION
Adds the needed `platformio.ini` plus a refactor of the `server.h` and `server.cpp` files because they confict with the Arduino-ESP8266 core files of `Server.h` and friends. This allows it to properly build on Windows which has a case-insenstive filenames and the wrong header file would be picked up, leading to compilation errors.

Folder structure is otherwise unchanged.

`platformio.ini` currently only builds the ESP8266 version of the fimware, but can also be expanded to build the AVR version of it.

Also see topic https://community.platformio.org/t/why-does-opensprinkler-firmware-for-esp8266-compile-in-visualmicro-and-arduino-but-not-in-this/18160