### PR TITLE
Correct platformio.ini, add ATMega1284P firmware

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,23 @@ board = d1_mini_lite
 framework = arduino
 lib_ldf_mode = deep
 lib_deps =
-     uipethernet/UIPEthernet @ ^2.0.8
+     UIPEthernet=https://github.com/OpenSprinkler/UIPEthernet/archive/fixes/dhcp.zip
      sui77/rc-switch @ ^2.6.3
-     squix78/ESP8266_SSD1306 @ ^4.1.0
+     https://github.com/ThingPulse/esp8266-oled-ssd1306/archive/4.2.0.zip
      knolleary/PubSubClient @ ^2.8
+; ignore html2raw.cpp source file for firmware compilation (external helper program)
+src_filter = +<*> -<html/*>
+
+[env:sanguino_atmega1284p]
+platform = atmelavr
+board = ATmega1284P
+board_build.f_cpu = 16000000L
+board_build.variant = sanguino
+framework = arduino
+lib_ldf_mode = deep
+lib_deps =
+     UIPEthernet=https://github.com/OpenSprinkler/UIPEthernet/archive/fixes/dhcp.zip
+     knolleary/PubSubClient @ ^2.8
+     greiman/SdFat @ 1.0.7
+     Wire
+src_filter = +<*> -<html/*>


### PR DESCRIPTION
This `platformio.ini` corrects several errors that have made this firmware uncompilable since the initial PR:
* the esp8266-oled-ssd1306 library was taken off the PlatformIO registry, now a direct link to the zip archive is used to install the library
* the source code in the html folder is ignored, otherwise we're trying to compile in a helper program
* an environment for the Sanduino ATMega1284P board has been added, faithfull to the original options in `make.os23`
* a modified version of the UIPEthernet library is used. Needed for DHCP fixes and exposing certain internal functions like `Ethernet.tick()`
* Version of the SdFat library fixed to 1.0.7

Now a simple `pio run` / Build in VSCode builds the ESP8266 and ATMega1284P firmwares :) 

```
...
Checking size .pio\build\d1_mini_lite\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [=====     ]  48.4% (used 39628 bytes from 81920 bytes)
Flash: [=====     ]  45.8% (used 438984 bytes from 958448 bytes)
Creating BIN file ".pio\build\d1_mini_lite\firmware.bin" using "C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\bootloaders\eboot\eboot.elf" and ".pio\build\d1_mini_lite\firmware.elf"
============ [SUCCESS] Took 12.14 seconds ============ 
..
Checking size .pio\build\sanguino_atmega1284p\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [=======   ]  69.9% (used 11452 bytes from 16384 bytes)
Flash: [=======   ]  72.2% (used 93886 bytes from 130048 bytes)
============ [SUCCESS] Took 7.55 seconds ============ 
...

Environment           Status    Duration
--------------------  --------  ------------
d1_mini_lite          SUCCESS   00:00:12.143
sanguino_atmega1284p  SUCCESS   00:00:07.550
============ 2 succeeded in 00:00:19.693 ============ 
```