### PR TITLE
Support retrieving group ids in scheduler-feature branch

### DIFF
--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -70,11 +70,14 @@ struct StationAttrib {	// station attributes
 	byte igs:1;	// ignore sensor 1
 	byte mas2:1;
 	byte dis:1;
+	byte unused:1;
 	byte igs2:1;// ignore sensor 2
 	byte igrd:1;// ignore rain delay
-	byte unused:1;
-	byte gid: 1; // group id 
-	
+	byte unused2:1;
+
+	byte gid:4;
+	byte dummy:4;
+
 	byte reserved[2]; // reserved bytes for the future
 }; // total is 4 bytes so far
 

--- a/defines.h
+++ b/defines.h
@@ -156,15 +156,15 @@ enum {
 };
 
 enum {
-	MASTER_STATION_ID = 0, 
-	MASTER_STATION_ON_AJD, 
+	MASTER_STATION_ID = 0,
+	MASTER_STATION_ON_AJD,
 	MASTER_STATION_OFF_ADJ,
 	NUM_MASTER_OPTS,
 };
 
-// Sequential Groups 
+// Sequential Groups
 #define NUM_SEQ_GROUPS		4
-#define PARALLEL_GROUP_ID	255
+#define PARALLEL_GROUP_ID	15
 
 // Date Range
 #define DATE_STR_LEN 		6 // "MM/DD"

--- a/server.cpp
+++ b/server.cpp
@@ -489,7 +489,7 @@ boolean check_password(char *p)
 	return false;
 }
 
-void server_json_stations_attrib(const char* name, byte *attrib)
+void server_json_board_attrib(const char* name, byte *attrib)
 {
 	bfill.emit_p(PSTR("\"$F\":["), name);
 	for(byte i=0;i<os.nboards;i++) {
@@ -500,14 +500,29 @@ void server_json_stations_attrib(const char* name, byte *attrib)
 	bfill.emit_p(PSTR("],"));
 }
 
+void server_json_stations_attrib(const char* name, byte *attrib)
+{
+	bfill.emit_p(PSTR("\"$F\":["), name);
+	for(byte bid=0;bid<os.nboards;bid++) {
+		for (byte s = 0; s < 8; s++) {
+			bfill.emit_p(PSTR("$D"), attrib[bid * 8 + s]);
+			if(bid != os.nboards-1 || s < 7) {
+				bfill.emit_p(PSTR(","));
+			}
+		}
+	}
+	bfill.emit_p(PSTR("],"));
+}
+
 void server_json_stations_main() {
-	server_json_stations_attrib(PSTR("masop"), os.attrib_mas);
-	server_json_stations_attrib(PSTR("masop2"), os.attrib_mas2);
-	server_json_stations_attrib(PSTR("ignore_rain"), os.attrib_igrd);  
-	server_json_stations_attrib(PSTR("ignore_sn1"), os.attrib_igs);
-	server_json_stations_attrib(PSTR("ignore_sn2"), os.attrib_igs2);
-	server_json_stations_attrib(PSTR("stn_dis"), os.attrib_dis);
-	server_json_stations_attrib(PSTR("stn_spe"), os.attrib_spe);
+	server_json_board_attrib(PSTR("masop"), os.attrib_mas);
+	server_json_board_attrib(PSTR("masop2"), os.attrib_mas2);
+	server_json_board_attrib(PSTR("ignore_rain"), os.attrib_igrd);
+	server_json_board_attrib(PSTR("ignore_sn1"), os.attrib_igs);
+	server_json_board_attrib(PSTR("ignore_sn2"), os.attrib_igs2);
+	server_json_board_attrib(PSTR("stn_dis"), os.attrib_dis);
+	server_json_board_attrib(PSTR("stn_spe"), os.attrib_spe);
+	server_json_stations_attrib(PSTR("stn_grp"), os.attrib_grp);
 
 	bfill.emit_p(PSTR("\"snames\":["));
 	byte sid;
@@ -595,7 +610,7 @@ void server_change_stations_attrib(char *p, char header, byte *attrib) {
  * i?: ignore rain bit field
  * n?: master2 operation bit field
  * d?: disable station bit field
- * q?: station sequeitnal bit field
+ * q?: station sequential bit field
  * p?: station special flag bit field
  * g?: sequential group id
  */
@@ -627,12 +642,12 @@ void server_change_stations() {
 	server_change_board_attrib(p, 'n', os.attrib_mas2); // master2
 	server_change_board_attrib(p, 'd', os.attrib_dis); // disable
 	server_change_board_attrib(p, 'p', os.attrib_spe); // special
-	server_change_stations_attrib(p, 'g', os.attrib_grp); // sequential groups 
+	server_change_stations_attrib(p, 'g', os.attrib_grp); // sequential groups
 
 	/* handle special data */
 	if(findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("sid"), true)) {
 		sid = atoi(tmp_buffer);
-		if (sid<0 || sid>os.nstations) handle_return(HTML_DATA_OUTOFBOUND); 
+		if (sid<0 || sid>os.nstations) handle_return(HTML_DATA_OUTOFBOUND);
 		if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("st"), true) &&
 			findKeyVal(p, tmp_buffer+1, TMP_BUFFER_SIZE-1, PSTR("sd"), true)) {
 
@@ -2402,5 +2417,3 @@ ulong getNtpTime()
 	return 0;
 }
 #endif
-
-


### PR DESCRIPTION
I'm trying to finish the work of grouping stations in the `scheduler-feature` branch so that I can use the feature on my OpenSprinkler.

This PR is just a small fix to support retrieving the group ids from the api, so that the frontend can display this information. Of course the frontend is in a different repo, so I'd like to get the firmware code approved first before I submit the PR for the frontend. There, I can use the presence of the `stn_grp` attribute I'm adding to determine whether station grouping is supported.