### PR TITLE
Set HTTP Port of Demo Mode by compiler parameter HTTP_PORT

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -581,7 +581,11 @@ void OpenSprinkler::reboot_dev(uint8_t cause) {
 byte OpenSprinkler::start_network() {
 	unsigned int port = (unsigned int)(iopts[IOPT_HTTPPORT_1]<<8) + (unsigned int)iopts[IOPT_HTTPPORT_0];
 #if defined(DEMO)
+#if defined(HTTP_PORT)
+	port = HTTP_PORT;
+#else
 	port = 80;
+#endif
 #endif
 	if(m_server) { delete m_server; m_server = 0; }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1418,10 +1418,10 @@ void push_message(int type, uint32_t lval, float fval, const char* sval) {
 			volume = lval*volume;
 			if (os.mqtt.enabled()) {
 				strcpy_P(topic, PSTR("opensprinkler/sensor/flow"));
-				sprintf_P(payload, PSTR("{\"count\":%lu,\"volume\":%d.%02d}"), lval, (int)volume/100, (int)volume%100);
+				sprintf_P(payload, PSTR("{\"count\":%u,\"volume\":%d.%02d}"), lval, (int)volume/100, (int)volume%100);
 			}
 			if (ifttt_enabled) {
-				sprintf_P(postval+strlen(postval), PSTR("Flow count: %lu, volume: %d.%02d"), lval, (int)volume/100, (int)volume%100);
+				sprintf_P(postval+strlen(postval), PSTR("Flow count: %u, volume: %d.%02d"), lval, (int)volume/100, (int)volume%100);
 			}
 			break;
 


### PR DESCRIPTION
Make HTTP Port in Demo Mode configurable by optional compiler parameter HTTP_PORT to get opensprinkler running on linux systems where port 80 is already in use. If new parameter is not set, port 80 is used.

Minor change in main.cpp to avoid compiler warnung. (changed %lu to %u in sprinf_T for lval.