### PR TITLE
firmware 2.1.9(11)

### DIFF
--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -35,7 +35,7 @@
 	#include <Arduino.h>
 	#include <Wire.h>
 	#include <SPI.h>
-	#include <Ethernet.h>
+	#include <UIPEthernet.h>
 	#include "I2CRTC.h"
 
 	#if defined(ESP8266)
@@ -254,9 +254,9 @@ public:
 	static void clear_all_station_bits(); // clear all station bits
 	static void apply_all_station_bits(); // apply all station bits (activate/deactive values)
 
-	static int8_t send_http_request(uint32_t ip4, uint16_t port, char* p, void(*callback)(char*)=NULL, uint16_t timeout=3000);
-	static int8_t send_http_request(const char* server, uint16_t port, char* p, void(*callback)(char*)=NULL, uint16_t timeout=3000);
-	static int8_t send_http_request(char* server_with_port, char* p, void(*callback)(char*)=NULL, uint16_t timeout=3000);  
+	static int8_t send_http_request(uint32_t ip4, uint16_t port, char* p, void(*callback)(char*)=NULL, uint16_t timeout=5000);
+	static int8_t send_http_request(const char* server, uint16_t port, char* p, void(*callback)(char*)=NULL, uint16_t timeout=5000);
+	static int8_t send_http_request(char* server_with_port, char* p, void(*callback)(char*)=NULL, uint16_t timeout=5000);
 	// -- LCD functions
 #if defined(ARDUINO) // LCD functions for Arduino
 	#if defined(ESP8266)

--- a/build.sh
+++ b/build.sh
@@ -22,8 +22,14 @@ elif [ "$1" == "osbo" ]; then
 	g++ -o OpenSprinkler -DOSBO main.cpp OpenSprinkler.cpp program.cpp opensprinkler_server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread -lmosquitto
 else
 	echo "Installing required libraries..."
+	apt-get update
 	apt-get install -y libmosquitto-dev
-	apt-get install -y wiringpi
+	apt-get install -y raspi-gpio
+	if ! command -v raspi-gpio &> /dev/null
+	then
+		echo "Command raspi-gpio is required and is not installed"
+		exit 0
+	fi
 	echo "Compiling firmware..."
 	g++ -o OpenSprinkler -DOSPI main.cpp OpenSprinkler.cpp program.cpp opensprinkler_server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread -lmosquitto
 fi

--- a/defines.h
+++ b/defines.h
@@ -24,7 +24,7 @@
 #ifndef _DEFINES_H
 #define _DEFINES_H
 
-//#define ENABLE_DEBUG  // enable serial debug
+#define ENABLE_DEBUG  // enable serial debug
 
 typedef unsigned char byte;
 typedef unsigned long ulong;
@@ -36,7 +36,7 @@ typedef unsigned long ulong;
                             // if this number is different from the one stored in non-volatile memory
                             // a device reset will be automatically triggered
 
-#define OS_FW_MINOR      9  // Firmware minor version
+#define OS_FW_MINOR     11  // Firmware minor version
 
 /** Hardware version base numbers */
 #define OS_HW_VERSION_BASE   0x00

--- a/gpio.cpp
+++ b/gpio.cpp
@@ -291,7 +291,8 @@ void pinMode(int pin, byte mode) {
 #if defined(OSPI)
 	if(mode==INPUT_PULLUP) {
 		char cmd[BUFFER_MAX];
-		snprintf(cmd, BUFFER_MAX, "gpio -g mode %d up", pin);
+		//snprintf(cmd, BUFFER_MAX, "gpio -g mode %d up", pin);
+		snprintf(cmd, BUFFER_MAX, "raspi-gpio set %d pu", pin);
 		system(cmd);
 	}
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -427,49 +427,6 @@ void do_loop()
 	if (m_server) {	// if wired Ethernet
 		led_blink_ms = 0;
 
-		#if defined(ENABLE_DEBUG)
-			// this section prints out ENC28J60 register values onto LCD
-			#define PHY_TIMEOUT 10
-			static ulong phy_timeout = 0;
-			static ulong n_reinits = 0;
-			if(curr_time >= phy_timeout) {
-				#define ENC28J60_EIR  	0x1C
-				#define ENC28J60_ESTAT	0x1D
-				#define ENC28J60_ECON1	0x1F
-
-				#define ENC28J60_EIR_RXERIF			0x01
-				#define ENC28J60_ESTAT_BUFER		0x40
-				#define ENC28J60_ESTAT_LATCOL		0x10
-				#define ENC28J60_ESTAT_TXABRT		0x02
-				#define ENC28J60_ECON1_RXEN			0x04
-				uint16_t estat = Enc28J60Network::readReg((uint8_t) ENC28J60_ESTAT);
-				uint16_t eir = Enc28J60Network::readReg((uint8_t) ENC28J60_EIR);
-				uint16_t econ1 = Enc28J60Network::readReg((uint8_t) ENC28J60_ECON1);
-
-				os.lcd.setCursor(0,-1);
-				os.lcd.print(eir, HEX);
-				os.lcd.print("|");
-				os.lcd.print(estat, HEX);
-				os.lcd.print("|");
-				os.lcd.print(econ1, HEX);
-				os.lcd.print("|");
-				os.lcd.print(n_reinits);
-				os.lcd.print(F("         "));
-
-				/* Detect possible enc28j60 problems */
-				if( (eir & ENC28J60_EIR_RXERIF) || (estat & ENC28J60_ESTAT_BUFER) ||
-					  (estat & ENC28J60_ESTAT_LATCOL) || (estat & ENC28J60_ESTAT_TXABRT) || 
-					  ((econ1 & ENC28J60_ECON1_RXEN) == 0) ) {
-					os.load_hardware_mac((uint8_t*)tmp_buffer, true);
-					Enc28J60Network::init((uint8_t*)tmp_buffer);
-					n_reinits ++;
-				}
-
-				phy_timeout = curr_time + PHY_TIMEOUT;
-			}		
-
-		#endif
-
 		static unsigned long dhcp_timeout = 0;
 		if(curr_time > dhcp_timeout) {
 			Ethernet.maintain();

--- a/make.lin32
+++ b/make.lin32
@@ -7,7 +7,7 @@ LIBS = . \
   $(ESP_LIBS)/ESP8266mDNS \
   ~/Arduino/libraries/SSD1306 \
   ~/Arduino/libraries/rc-switch \
-  ~/Arduino/libraries/EthernetENC \
+  ~/Arduino/libraries/UIPEthernet \
   ~/Arduino/libraries/pubsubclient \
 
 ESP_ROOT = $(HOME)/esp8266_2.7.4/

--- a/make.os23
+++ b/make.os23
@@ -9,7 +9,7 @@ BOARD_TAG = 1284
 MCU = atmega1284p
 VARIANT = sanguino
 F_CPU = 16000000L
-ARDUINO_LIBS = EthernetENC Wire SdFat SPI pubsubclient
+ARDUINO_LIBS = UIPEthernet Wire SdFat SPI pubsubclient
 MONITOR_PORT = /dev/ttyUSB0
 MONITOR_BAUDRATE = 115200
 include ./Arduino.mk

--- a/mqtt.cpp
+++ b/mqtt.cpp
@@ -26,7 +26,7 @@
 	#if defined(ESP8266)
 		#include <ESP8266WiFi.h>
 	#endif
-	#include <Ethernet.h>
+	#include <UIPEthernet.h>
 	#include <PubSubClient.h>
 
 	struct PubSubClient *mqtt_client = NULL;

--- a/opensprinkler_server.cpp
+++ b/opensprinkler_server.cpp
@@ -2159,6 +2159,7 @@ ulong getNtpTime() {
 		os.iopts[IOPT_NTP_IP4]};
 	byte tries=0;
 	ulong gt = 0;
+	ulong startt = millis();
 	while(tries<NTP_NTRIES) {
 		// sendNtpPacket
 		udp->begin(port);
@@ -2214,6 +2215,9 @@ ulong getNtpTime() {
 				if(gt>1577836800UL) {
 					udp->stop();
 					delete udp;
+					DEBUG_PRINT(F("took "));
+					DEBUG_PRINT(millis()-startt);
+					DEBUG_PRINTLN(F("ms"));
 					return gt;
 				}
 			}

--- a/weather.cpp
+++ b/weather.cpp
@@ -42,6 +42,7 @@ void write_log(byte type, ulong curr_time);
 
 static void getweather_callback(char* buffer) {
 	char *p = buffer;
+	DEBUG_PRINTLN(p);
 	/* scan the buffer until the first & symbol */
 	while(*p && *p!='&') {
 		p++;
@@ -49,7 +50,6 @@ static void getweather_callback(char* buffer) {
 	if (*p != '&')	return;
 	int v;
 	bool save_nvdata = false;
-	
 	// first check errCode, only update lswc timestamp if errCode is 0
 	if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("errCode"), true)) {
 		wt_errCode = atoi(tmp_buffer);


### PR DESCRIPTION
Improve send_http_request to accommodate larger incoming packets (particularly weather requests for which CloudFlare imposes large header information).
Replace EthernetENC library by UIPEthernet, which is likely more stable as it's more recent. This affects OS 3.x using wired Ethernet, and also OS 2.3.
Replace wiringPi by raspi-gpio which is available on the latest Raspbian. This affects OSPi.