### PR TITLE
feat: prepare for OrangePi boards

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -93,7 +93,7 @@ extern ProgramData pd;
 	LiquidCrystal OpenSprinkler::lcd;
 	extern SdFat sd;
 #else
-	#if defined(OSPI)
+	#if defined(OSPI) || defined(OSOPI)
 		byte OpenSprinkler::pin_sr_data = PIN_SR_DATA;
 	#endif
 	// todo future: LCD define for Linux-based systems
@@ -882,7 +882,7 @@ void OpenSprinkler::begin() {
 
 	pinMode(PIN_SR_CLOCK, OUTPUT);
 
-	#if defined(OSPI)
+	#if defined(OSPI) || defined(OSOPI)
 		pin_sr_data = PIN_SR_DATA;
 		// detect RPi revision
 		unsigned int rev = detect_rpi_rev();
@@ -1254,7 +1254,7 @@ void OpenSprinkler::apply_all_station_bits() {
 
 		for(s=0;s<8;s++) {
 			digitalWrite(PIN_SR_CLOCK, LOW);
-	#if defined(OSPI) // if OSPI, use dynamically assigned pin_sr_data
+	#if defined(OSPI) || defined(OSOPI) // if OSPI, use dynamically assigned pin_sr_data
 			digitalWrite(pin_sr_data, (sbits & ((byte)1<<(7-s))) ? HIGH : LOW );
 	#else
 			digitalWrite(PIN_SR_DATA, (sbits & ((byte)1<<(7-s))) ? HIGH : LOW );

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -205,7 +205,7 @@ public:
 	// todo: LCD define for RPI/BBB
 #endif
 
-#if defined(OSPI)
+#if defined(OSPI) || defined(OSOPI)
 	static byte pin_sr_data;  // RPi shift register data pin to handle RPi rev. 1
 #endif
 

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,32 @@ elif [ "$1" == "osbo" ]; then
 	apt-get install -y libmosquitto-dev
 	echo "Compiling firmware..."
 	g++ -o OpenSprinkler -DOSBO -std=c++14 main.cpp OpenSprinkler.cpp program.cpp opensprinkler_server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread -lmosquitto
+elif [ "$1" == "opipc" ]; then
+	echo "Installing required libraries..."
+	apt-get update
+	apt-get install -y libmosquitto-dev
+	echo "Downloading and installing wiringOP..."
+	if [ -d "wiringOP" ]; then
+		echo "wiringOP folder exists, updating to latest master"
+		cd wiringOP
+		git checkout master
+		git pull
+	else
+		git clone https://github.com/orangepi-xunlong/wiringOP.git
+		cd wiringOP
+	fi
+	./build clean
+	./build 
+	cd ..
+	echo "Done installing wiringOP"
+	if ! command -v gpio &> /dev/null
+	then
+		echo "Command gpio is required and is not installed"
+		exit 0
+	fi
+	echo "Compiling firmware..."
+	g++ -o OpenSprinkler -DOSOPI -std=c++14 main.cpp OpenSprinkler.cpp program.cpp opensprinkler_server.cpp utils.cpp weather.cpp gpio.cpp etherport.cpp mqtt.cpp -lpthread -lmosquitto
+
 else
 	echo "Installing required libraries..."
 	apt-get update

--- a/defines.h
+++ b/defines.h
@@ -422,6 +422,24 @@ enum {
 	#define PIN_FREE_LIST       {5,6,7,8,9,10,11,12,13,16,18,19,20,21,23,24,25,26}  // free GPIO pins
 	#define ETHER_BUFFER_SIZE   16384
 
+#elif defined(OSOPI) // for OSPi on OrangePi
+
+	#define OS_HW_VERSION    OSPI_HW_VERSION_BASE
+	#define PIN_SR_LATCH       3    // shift register latch pin
+	#define PIN_SR_DATA        0    // shift register data pin
+	#define PIN_SR_DATA_ALT  199    // shift register data pin (alternative, for RPi 1 rev. 1 boards)
+	#define PIN_SR_CLOCK       6    // shift register clock pin
+	#define PIN_SR_OE          1    // shift register output enable pin
+	#define PIN_SENSOR1       13
+	#define PIN_SENSOR2       68
+	#define PIN_RFTX          14    // RF transmitter pin
+	//#define PIN_BUTTON_1      23    // button 1
+	//#define PIN_BUTTON_2      24    // button 2
+	//#define PIN_BUTTON_3      25    // button 3
+
+	#define PIN_FREE_LIST       {2,7,8,9,10,11,12,18,19,20,21,64,65,66,67,71,110,198,200,201}  // free GPIO pins
+	#define ETHER_BUFFER_SIZE   16384
+
 #elif defined(OSBO) // for OSBo
 
 	#define OS_HW_VERSION    OSBO_HW_VERSION_BASE

--- a/gpio.cpp
+++ b/gpio.cpp
@@ -175,7 +175,7 @@ byte digitalReadExt(byte pin) {
 }
 #endif
 
-#elif defined(OSPI) || defined(OSBO)
+#elif defined(OSPI) || defined(OSBO) || defined(OSOPI)
 
 #include <sys/types.h>
 #include <sys/ioctl.h>
@@ -281,7 +281,7 @@ void pinMode(int pin, byte mode) {
 	}
 
 	close(fd);
-#if defined(OSPI)
+#if defined(OSPI) || defined(OSOPI)
 	if(mode==INPUT_PULLUP) {
 		char cmd[BUFFER_MAX];
 		//snprintf(cmd, BUFFER_MAX, "gpio -g mode %d up", pin);

--- a/gpio.h
+++ b/gpio.h
@@ -125,7 +125,7 @@ byte digitalReadExt(byte pin);
 #define OUTPUT 0
 #define INPUT  1
 
-#if defined(OSPI)
+#if defined(OSPI) || defined(OSOPI)
 #define INPUT_PULLUP 2
 #else
 #define INPUT_PULLUP INPUT

--- a/utils.cpp
+++ b/utils.cpp
@@ -143,7 +143,7 @@ ulong micros (void)
 	return (ulong)(now - epochMicro) ;
 }
 
-#if defined(OSPI)
+#if defined(OSPI) || defined(OSOPI)
 unsigned int detect_rpi_rev() {
 	FILE * filp;
 	unsigned int rev;

--- a/utils.h
+++ b/utils.h
@@ -78,7 +78,7 @@ void str2mac(const char *_str, byte mac[]);
 	ulong millis();
 	ulong micros();
 	void initialiseEpoch();
-	#if defined(OSPI)
+	#if defined(OSPI) || defined(OSOPI)
 	unsigned int detect_rpi_rev();
 	#endif
 


### PR DESCRIPTION
I had a OrangePi PC board laying around and wanted to use it with OpenSprinkler. It's based on a Allwinner H3. According to the documentation, all OrangePi One/Lite/Pc/Plus/PcPlus/Plus2e should be usable with OpenSprinkler with my changes immediately.

Works with Armbian 23.02 Jammy 
