### PR TITLE
Memory Leak during WiFi reconnect

### DIFF
--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -66,6 +66,7 @@
 	#if defined(ESP8266)
 	extern ESP8266WebServer *update_server;
 	extern OTF::OpenThingsFramework *otf;
+	extern bool otf_callbacksInitialised;
 	extern ENC28J60lwIP eth;
 	#else
 	extern EthernetServer *m_server;

--- a/main.cpp
+++ b/main.cpp
@@ -33,6 +33,7 @@
 	#if defined(ESP8266)
 		ESP8266WebServer *update_server = NULL;
 		OTF::OpenThingsFramework *otf = NULL;
+		bool otf_callbacksInitialised = false;
 		DNSServer *dns = NULL;
 		ENC28J60lwIP eth(PIN_ETHER_CS); // ENC28J60 lwip for wired Ether
 		bool useEth = false; // tracks whether we are using WiFi or wired Ether connection

--- a/opensprinkler_server.cpp
+++ b/opensprinkler_server.cpp
@@ -2093,21 +2093,23 @@ void on_ap_upload() { on_sta_upload(); }
 
 void start_server_client() {
 	if(!otf) return;
+        if (otf_callbacksInitialised == false){
+			otf->on("/", server_home);  // handle home page
+			otf->on("/index.html", server_home);
+			otf->on("/update", on_sta_update, OTF::HTTP_GET); // handle firmware update
+			update_server->on("/update", HTTP_POST, on_sta_upload_fin, on_sta_upload);
 
-	otf->on("/", server_home);  // handle home page
-	otf->on("/index.html", server_home);
-	otf->on("/update", on_sta_update, OTF::HTTP_GET); // handle firmware update
-	update_server->on("/update", HTTP_POST, on_sta_upload_fin, on_sta_upload);
-
-	// set up all other handlers
-	char uri[4];
-	uri[0]='/';
-	uri[3]=0;
-	for(byte i=0;i<sizeof(urls)/sizeof(URLHandler);i++) {
-		uri[1]=pgm_read_byte(_url_keys+2*i);
-		uri[2]=pgm_read_byte(_url_keys+2*i+1);
-		otf->on(uri, urls[i]);
-	}
+			// set up all other handlers
+			char uri[4];
+			uri[0]='/';
+			uri[3]=0;
+			for(byte i=0;i<sizeof(urls)/sizeof(URLHandler);i++) {
+				uri[1]=pgm_read_byte(_url_keys+2*i);
+				uri[2]=pgm_read_byte(_url_keys+2*i+1);
+				otf->on(uri, urls[i]);
+			}
+            otf_callbacksInitialised = true;
+        }
 	update_server->begin();
 }
 


### PR DESCRIPTION
Every time the firmware reestablished the WiFi connection, HEAP memory decreased by more or less 5 kByte.
As a result the firmware stopped processing the station programs after the second or third reconnect. The firmware restarted automatically, when it was contacted via app or web GUI.

Problem was in function start_server_client. The call of this function adds the callbacks for the OpenThingsFramework. This function is called during each reconnect.
Because there is neither a function called, which removes the callbacks nor a check to prevent duplicate callback entries, the callbacks were added at the end of the callback list each time.

### Solution
Now an 'initialised' flag prevents the duplicate insertions.

### Hint
A better solution would be, to correct LinkedMapNode in the way, that it prevents the insertion of duplicate keys.
I did not do this, because I currently can not estimate the influences of such changes in this central object.


