### PR TITLE
firmware 2.2.1(2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ OpenSprinkler
 wtopts.txt
 *.dat
 *.sh
-testmode.h
 build-1284/*
 .vscode
 .pio

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -910,8 +910,10 @@ void OpenSprinkler::begin() {
 			PIN_SENSOR1 = V1_PIN_SENSOR1;
 			PIN_SENSOR2 = V1_PIN_SENSOR2;
 		} else {
-			// revision 2 and 3
-			if(detect_i2c(EEPROM_I2CADDR)) { // revision 3 has a I2C EEPROM
+			// revision 2 and above
+			if(detect_i2c(EEPROM_I2CADDR+2)) { // revision 4 has an I2C EEPROM at this address; skipping +1 due to addr conflict with PCF8563
+				hw_rev = 4;
+			} else if(detect_i2c(EEPROM_I2CADDR)) { // revision 3 has an I2C EEPROM at this address
 				hw_rev = 3;
 			} else {
 				hw_rev = 2;

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -460,9 +460,9 @@ static const char days_str[] PROGMEM =
 
 #if !defined(ARDUINO)
 static inline int32_t now() {
-    time_t rawtime;
-    time(&rawtime);
-    return rawtime;
+	time_t rawtime;
+	time(&rawtime);
+	return rawtime;
 }
 #endif
 /** Calculate local time (UTC time plus time zone offset) */
@@ -561,7 +561,7 @@ unsigned char OpenSprinkler::start_ether() {
 	SPI.begin();
 	SPI.setBitOrder(MSBFIRST);
 	SPI.setDataMode(SPI_MODE0);
-	SPI.setFrequency(10000000L); // set 10MHz SPI frequency
+	SPI.setFrequency(ETHER_SPI_CLOCK); // set SPI frequency
 
 	if(eth.isW5500) {
 		DEBUG_PRINTLN(F("detect existence of W5500"));
@@ -1128,16 +1128,16 @@ void OpenSprinkler::latch_boost(unsigned char volt) {
 		delay((int)iopts[IOPT_BOOST_TIME]<<2); // wait for booster to charge
 		digitalWriteExt(PIN_BOOST, LOW);       // disable boost converter
 	} else {
-    // boost to specified volt, up to time specified by BOOST_TIME
-    uint16_t top = (uint16_t)(volt * 19.25f); // ADC = 1024 * volt * 1.5k / 79.8k
+		// boost to specified volt, up to time specified by BOOST_TIME
+		uint16_t top = (uint16_t)(volt * 19.25f); // ADC = 1024 * volt * 1.5k / 79.8k
 		if(analogRead(PIN_CURR_SENSE)>=top) return; // if the voltage has already reached top, return right away
-    uint32_t boost_timeout = millis() + (iopts[IOPT_BOOST_TIME]<<2);
-    digitalWriteExt(PIN_BOOST, HIGH);
-    // boost until either top voltage is reached or boost timeout is reached
-    while(millis()<boost_timeout && analogRead(PIN_CURR_SENSE)<top) {
-      delay(5);
-    }
-    digitalWriteExt(PIN_BOOST, LOW);
+		uint32_t boost_timeout = millis() + (iopts[IOPT_BOOST_TIME]<<2);
+		digitalWriteExt(PIN_BOOST, HIGH);
+		// boost until either top voltage is reached or boost timeout is reached
+		while(millis()<boost_timeout && analogRead(PIN_CURR_SENSE)<top) {
+			delay(5);
+		}
+		digitalWriteExt(PIN_BOOST, LOW);
 	}
 }
 
@@ -2080,7 +2080,7 @@ void OpenSprinkler::switch_remotestation(RemoteIPStationData *data, bool turnon,
 	ip[3] = ip4&0xff;
 
 	char *p = tmp_buffer;
-    BufferFiller bf = BufferFiller(p, TMP_BUFFER_SIZE*2);
+	BufferFiller bf = BufferFiller(p, TMP_BUFFER_SIZE*2);
 	// if turning on the zone and duration is defined, give duration as the timer value
 	// otherwise:
 	//   if autorefresh is defined, we give a fixed duration each time, and auto refresh will renew it periodically
@@ -2100,7 +2100,7 @@ void OpenSprinkler::switch_remotestation(RemoteIPStationData *data, bool turnon,
 	bf.emit_p(PSTR(" HTTP/1.0\r\nHOST: $D.$D.$D.$D\r\n"),
 						ip[0],ip[1],ip[2],ip[3]);
 
-    bf.emit_p(PSTR(" User-Agent: $S\r\n\r\n"), user_agent_string);
+	bf.emit_p(PSTR(" User-Agent: $S\r\n\r\n"), user_agent_string);
 
 	char server[20];
 	snprintf(server, 20, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
@@ -2139,9 +2139,9 @@ void OpenSprinkler::switch_remotestation(RemoteOTCStationData *data, bool turnon
 						turnon, timer);
 	bf.emit_p(PSTR(" HTTP/1.0\r\nHOST: $S\r\nConnection:close\r\n"), DEFAULT_OTC_SERVER_APP);
 
-    bf.emit_p(PSTR(" User-Agent: $S\r\n\r\n"), user_agent_string);
+	bf.emit_p(PSTR(" User-Agent: $S\r\n\r\n"), user_agent_string);
 
-	int x = send_http_request(DEFAULT_OTC_SERVER_APP, DEFAULT_OTC_PORT_APP, p, remote_http_callback, true);
+	send_http_request(DEFAULT_OTC_SERVER_APP, DEFAULT_OTC_PORT_APP, p, remote_http_callback, true);
 }
 
 /** Switch http(s) station
@@ -2165,7 +2165,7 @@ void OpenSprinkler::switch_httpstation(HTTPStationData *data, bool turnon, bool 
 	if(cmd==NULL || server==NULL) return; // proceed only if cmd and server are valid
 
 	bf.emit_p(PSTR("GET /$S HTTP/1.0\r\nHOST: $S\r\n"), cmd, server);
-    bf.emit_p(PSTR(" User-Agent: $S\r\n\r\n"), user_agent_string);
+	bf.emit_p(PSTR(" User-Agent: $S\r\n\r\n"), user_agent_string);
 
 	send_http_request(server, atoi(port), p, remote_http_callback, usessl);
 }
@@ -2668,15 +2668,15 @@ void OpenSprinkler::lcd_print_mac(const unsigned char *mac) {
 		lcd.print((mac[i]&0x0F), HEX);
 		if(i==4) lcd.setCursor(0, 1);
 	}
-    #if defined(ARDUINO)
+	#if defined(ARDUINO)
 	if(useEth) {
 		lcd_print_pgm(PSTR(" (Ether MAC)"));
 	} else {
 		lcd_print_pgm(PSTR(" (WiFi MAC)"));
 	}
-    #else
-        lcd_print_pgm(PSTR(" (MAC)"));
-    #endif
+	#else
+		lcd_print_pgm(PSTR(" (MAC)"));
+	#endif
 
 	#if defined(USE_SSD1306)
 		lcd.display();
@@ -2768,18 +2768,19 @@ void OpenSprinkler::lcd_print_screen(char c) {
 	if(useEth) {
 		lcd.write(eth.connected()?ICON_ETHER_CONNECTED:ICON_ETHER_DISCONNECTED);
 	}
-	else
+	else {
 		lcd.write(WiFi.status()==WL_CONNECTED?ICON_WIFI_CONNECTED:ICON_WIFI_DISCONNECTED);
+	}
 #else
 	lcd.write(status.network_fails>2?ICON_ETHER_DISCONNECTED:ICON_ETHER_CONNECTED);  // if network failure detection is more than 2, display disconnect icon
 #endif
 
 #if defined(USE_SSD1306)
-    #if defined(ESP8266)
-    if(useEth || (get_wifi_mode()==WIFI_MODE_STA && WiFi.status()==WL_CONNECTED && WiFi.localIP())) {
-    #else
-    {
-    #endif
+	#if defined(ESP8266)
+	if(useEth || (get_wifi_mode()==WIFI_MODE_STA && WiFi.status()==WL_CONNECTED && WiFi.localIP())) {
+	#else
+	{
+	#endif
 		lcd.setCursor(0, -1);
 		if(status.rain_delayed) {
 			lcd.print(F("<Rain Delay On> "));
@@ -2791,16 +2792,16 @@ void OpenSprinkler::lcd_print_screen(char c) {
 			lcd.print(F(" (System Idle)  "));
 		}
 
-    #if defined(ESP8266)
+	#if defined(ESP8266)
 		lcd.setCursor(2, 2);
 		if(status.program_busy && !status.pause_state) {
 			//lcd.print(F("Curr: "));
 			lcd.print(read_current());
 			lcd.print(F(" mA      "));
 		} else {
-    #else
-        {
-    #endif
+	#else
+		{
+	#endif
 			lcd.clear(2, 2);
 		}
 	}

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -2093,7 +2093,7 @@ void OpenSprinkler::switch_remotestation(RemoteIPStationData *data, bool turnon,
 	bf.emit_p(PSTR(" HTTP/1.0\r\nHOST: $D.$D.$D.$D\r\n"),
 						ip[0],ip[1],ip[2],ip[3]);
 
-	bf.emit_p(PSTR(" User-Agent: $S\r\n\r\n"), user_agent_string);
+	bf.emit_p(PSTR("User-Agent: $S\r\n\r\n"), user_agent_string);
 
 	char server[20];
 	snprintf(server, 20, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
@@ -2132,7 +2132,7 @@ void OpenSprinkler::switch_remotestation(RemoteOTCStationData *data, bool turnon
 						turnon, timer);
 	bf.emit_p(PSTR(" HTTP/1.0\r\nHOST: $S\r\nConnection:close\r\n"), DEFAULT_OTC_SERVER_APP);
 
-	bf.emit_p(PSTR(" User-Agent: $S\r\n\r\n"), user_agent_string);
+	bf.emit_p(PSTR("User-Agent: $S\r\n\r\n"), user_agent_string);
 
 	send_http_request(DEFAULT_OTC_SERVER_APP, DEFAULT_OTC_PORT_APP, p, remote_http_callback, true);
 }
@@ -2158,7 +2158,7 @@ void OpenSprinkler::switch_httpstation(HTTPStationData *data, bool turnon, bool 
 	if(cmd==NULL || server==NULL) return; // proceed only if cmd and server are valid
 
 	bf.emit_p(PSTR("GET /$S HTTP/1.0\r\nHOST: $S\r\n"), cmd, server);
-	bf.emit_p(PSTR(" User-Agent: $S\r\n\r\n"), user_agent_string);
+	bf.emit_p(PSTR("User-Agent: $S\r\n\r\n"), user_agent_string);
 
 	send_http_request(server, atoi(port), p, remote_http_callback, usessl);
 }

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -647,12 +647,6 @@ unsigned char OpenSprinkler::start_ether() {
 	lcd_print_line_clear_pgm(PSTR(""), 2);
 	if(eth.connected()) {
 		// if wired connection is successful at this point, copy the network ips to config
-		DEBUG_PRINTLN();
-		DEBUG_PRINT("eth.ip:");
-		DEBUG_PRINTLN(eth.localIP());
-		DEBUG_PRINT("eth.dns:");
-		DEBUG_PRINTLN(WiFi.dnsIP());
-
 		if (iopts[IOPT_USE_DHCP]) {
 			memcpy(iopts+IOPT_STATIC_IP1, &(eth.localIP()[0]), 4);
 			memcpy(iopts+IOPT_GATEWAY_IP1, &(eth.gatewayIP()[0]),4);
@@ -1411,7 +1405,7 @@ void OpenSprinkler::apply_all_station_bits() {
 void OpenSprinkler::detect_binarysensor_status(time_os_t curr_time) {
 	// sensor_type: 0 if normally closed, 1 if normally open
 	if(iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_RAIN || iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_SOIL) {
-		if(hw_rev>=2)	pinModeExt(PIN_SENSOR1, INPUT_PULLUP); // this seems necessary for OS 3.2
+		if(hw_rev>=2)	pinMode(PIN_SENSOR1, INPUT_PULLUP); // this seems necessary for OS 3.2
 		unsigned char val = digitalReadExt(PIN_SENSOR1);
 		status.sensor1 = (val == iopts[IOPT_SENSOR1_OPTION]) ? 0 : 1;
 		if(status.sensor1) {
@@ -1441,7 +1435,7 @@ void OpenSprinkler::detect_binarysensor_status(time_os_t curr_time) {
 // ESP8266 is guaranteed to have sensor 2
 #if defined(ESP8266) || defined(PIN_SENSOR2)
 	if(iopts[IOPT_SENSOR2_TYPE]==SENSOR_TYPE_RAIN || iopts[IOPT_SENSOR2_TYPE]==SENSOR_TYPE_SOIL) {
-		if(hw_rev>=2)	pinModeExt(PIN_SENSOR2, INPUT_PULLUP); // this seems necessary for OS 3.2
+		if(hw_rev>=2)	pinMode(PIN_SENSOR2, INPUT_PULLUP); // this seems necessary for OS 3.2
 		unsigned char val = digitalReadExt(PIN_SENSOR2);
 		status.sensor2 = (val == iopts[IOPT_SENSOR2_OPTION]) ? 0 : 1;
 		if(status.sensor2) {
@@ -1476,7 +1470,7 @@ unsigned char OpenSprinkler::detect_programswitch_status(time_os_t curr_time) {
 	unsigned char ret = 0;
 	if(iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_PSWITCH) {
 		static unsigned char sensor1_hist = 0;
-		if(hw_rev>=2) pinModeExt(PIN_SENSOR1, INPUT_PULLUP); // this seems necessary for OS 3.2
+		if(hw_rev>=2) pinMode(PIN_SENSOR1, INPUT_PULLUP); // this seems necessary for OS 3.2
 		status.sensor1 = (digitalReadExt(PIN_SENSOR1) != iopts[IOPT_SENSOR1_OPTION]); // is switch activated?
 		sensor1_hist = (sensor1_hist<<1) | status.sensor1;
 		// basic noise filtering: only trigger if sensor matches pattern:
@@ -1488,7 +1482,7 @@ unsigned char OpenSprinkler::detect_programswitch_status(time_os_t curr_time) {
 #if defined(ESP8266) || defined(PIN_SENSOR2)
 	if(iopts[IOPT_SENSOR2_TYPE]==SENSOR_TYPE_PSWITCH) {
 		static unsigned char sensor2_hist = 0;
-		if(hw_rev>=2) pinModeExt(PIN_SENSOR2, INPUT_PULLUP); // this seems necessary for OS 3.2
+		if(hw_rev>=2) pinMode(PIN_SENSOR2, INPUT_PULLUP); // this seems necessary for OS 3.2
 		status.sensor2 = (digitalReadExt(PIN_SENSOR2) != iopts[IOPT_SENSOR2_OPTION]); // is sensor activated?
 		sensor2_hist = (sensor2_hist<<1) | status.sensor2;
 		if((sensor2_hist&0b1111) == 0b0011) {
@@ -1965,7 +1959,6 @@ int8_t OpenSprinkler::send_http_request(const char* server, uint16_t port, char*
 		DEBUG_PRINT("(");
 		DEBUG_PRINT(tries);
 		DEBUG_PRINTLN(")");
-
 		if(client->connect(server, port)==1) break;
 		tries++;
 	} while(tries<HTTP_CONNECT_NTRIES);

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -1105,9 +1105,9 @@ pinModeExt(PIN_BUTTON_3, INPUT_PULLUP);
 
 	// set button pins
 	// enable internal pullup
-	pinMode(PIN_BUTTON_1, INPUT_PULLUP);
-	pinMode(PIN_BUTTON_2, INPUT_PULLUP);
-	pinMode(PIN_BUTTON_3, INPUT_PULLUP);
+	pinModeExt(PIN_BUTTON_1, INPUT_PULLUP);
+	pinModeExt(PIN_BUTTON_2, INPUT_PULLUP);
+	pinModeExt(PIN_BUTTON_3, INPUT_PULLUP);
 
 	// detect and check RTC type
 	RTC.detect();

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -561,7 +561,7 @@ unsigned char OpenSprinkler::start_ether() {
 	SPI.begin();
 	SPI.setBitOrder(MSBFIRST);
 	SPI.setDataMode(SPI_MODE0);
-	SPI.setFrequency(4000000);
+	SPI.setFrequency(10000000L); // set 10MHz SPI frequency
 
 	if(eth.isW5500) {
 		DEBUG_PRINTLN(F("detect existence of W5500"));

--- a/defines.h
+++ b/defines.h
@@ -93,7 +93,7 @@ typedef unsigned long ulong;
 #define SENSOR_TYPE_PSWITCH 0xF0  // program switch sensor
 #define SENSOR_TYPE_OTHER   0xFF
 
-#define FLOWCOUNT_RT_WINDOW   100000  // flow count divisor (for computing real-time flow rate)
+#define FLOWCOUNT_RT_WINDOW   1000  // flow count divisor (for computing real-time flow rate)
 
 /** Reboot cause */
 #define REBOOT_CAUSE_NONE   0

--- a/defines.h
+++ b/defines.h
@@ -494,7 +494,11 @@ enum {
 
 #else
 
+	#if defined(ARDUINO)
+	#define DEBUG_BEGIN(x)   {Serial.begin(115200);Serial.end();}
+	#else
 	#define DEBUG_BEGIN(x)   {}
+	#endif
 	#define DEBUG_PRINT(x)   {}
 	#define DEBUG_PRINTLN(x) {}
 	#define DEBUG_PRINTF(x, ...)  {}

--- a/defines.h
+++ b/defines.h
@@ -93,7 +93,7 @@ typedef unsigned long ulong;
 #define SENSOR_TYPE_PSWITCH 0xF0  // program switch sensor
 #define SENSOR_TYPE_OTHER   0xFF
 
-#define FLOWCOUNT_RT_WINDOW   100000  // flow count window (for computing real-time flow rate), 30 seconds
+#define FLOWCOUNT_RT_WINDOW   100000  // flow count divisor (for computing real-time flow rate)
 
 /** Reboot cause */
 #define REBOOT_CAUSE_NONE   0

--- a/defines.h
+++ b/defines.h
@@ -495,7 +495,8 @@ enum {
 #else
 
 	#if defined(ARDUINO)
-	#define DEBUG_BEGIN(x)   {Serial.begin(115200);Serial.end();}
+	// work-around for PIN_SENSOR1 on OS3.2 and above
+	#define DEBUG_BEGIN(x)   {Serial.begin(115200); Serial.end();}
 	#else
 	#define DEBUG_BEGIN(x)   {}
 	#endif

--- a/defines.h
+++ b/defines.h
@@ -364,6 +364,7 @@ enum {
 	#define ETHER_BUFFER_SIZE   2048
 
 	#define PIN_ETHER_CS       16 // Ethernet CS (chip select pin) is 16 on OS 3.2 and above
+	#define ETHER_SPI_CLOCK    20000000L // SPI clock for Ethernet (e.g. 20MHz)
 
 	/* To accommodate different OS30 versions, we use software defines pins */
 	extern unsigned char PIN_BUTTON_1;

--- a/defines.h
+++ b/defines.h
@@ -35,7 +35,7 @@ typedef unsigned long ulong;
 														// if this number is different from the one stored in non-volatile memory
 														// a device reset will be automatically triggered
 
-#define OS_FW_MINOR      1  // Firmware minor version
+#define OS_FW_MINOR      2  // Firmware minor version
 
 /** Hardware version base numbers */
 #define OS_HW_VERSION_BASE   0x00 // OpenSprinkler
@@ -80,10 +80,10 @@ typedef unsigned long ulong;
 
 /** HTTP request macro defines */
 #define HTTP_RQT_SUCCESS       0
-#define HTTP_RQT_NOT_RECEIVED  1
-#define HTTP_RQT_CONNECT_ERR   2
-#define HTTP_RQT_TIMEOUT       3
-#define HTTP_RQT_EMPTY_RETURN  4
+#define HTTP_RQT_NOT_RECEIVED  -1
+#define HTTP_RQT_CONNECT_ERR   -2
+#define HTTP_RQT_TIMEOUT       -3
+#define HTTP_RQT_EMPTY_RETURN  -4
 
 /** Sensor macro defines */
 #define SENSOR_TYPE_NONE    0x00

--- a/defines.h
+++ b/defines.h
@@ -93,7 +93,7 @@ typedef unsigned long ulong;
 #define SENSOR_TYPE_PSWITCH 0xF0  // program switch sensor
 #define SENSOR_TYPE_OTHER   0xFF
 
-#define FLOWCOUNT_RT_WINDOW   30  // flow count window (for computing real-time flow rate), 30 seconds
+#define FLOWCOUNT_RT_WINDOW   100000  // flow count window (for computing real-time flow rate), 30 seconds
 
 /** Reboot cause */
 #define REBOOT_CAUSE_NONE   0

--- a/defines.h
+++ b/defines.h
@@ -364,7 +364,7 @@ enum {
 	#define ETHER_BUFFER_SIZE   2048
 
 	#define PIN_ETHER_CS       16 // Ethernet CS (chip select pin) is 16 on OS 3.2 and above
-	#define ETHER_SPI_CLOCK    20000000L // SPI clock for Ethernet (e.g. 20MHz)
+	#define ETHER_SPI_CLOCK    10000000L // SPI clock for Ethernet (e.g. 10MHz)
 
 	/* To accommodate different OS30 versions, we use software defines pins */
 	extern unsigned char PIN_BUTTON_1;

--- a/gpio.cpp
+++ b/gpio.cpp
@@ -217,52 +217,50 @@ struct gpiod_line* gpio_lines[] = {
 
 int assert_gpiod_chip() {
 	if( !chip ) {
-        const char *chip_name = NULL;
+		const char *chip_name = NULL;
 
-        switch (get_board_type()) {
-            case BoardType::RaspberryPi_bcm2712:
-                chip_name = "pinctrl-rp1";
-                break;
-            case BoardType::RaspberryPi_bcm2711:
-                chip_name = "pinctrl-bcm2711";
-                break;
-            case BoardType::RaspberryPi_bcm2837:
-            case BoardType::RaspberryPi_bcm2836:
-            case BoardType::RaspberryPi_bcm2835:
-                chip_name = "pinctrl-bcm2835";
-                break;
-            case BoardType::Unknown: 
-            case BoardType::RaspberryPi_Unknown: 
-            default:
-            // Unknown chip
-            break;
-        }
+		switch (get_board_type()) {
+			case BoardType::RaspberryPi_bcm2712:
+				chip_name = "pinctrl-rp1";
+				break;
+			case BoardType::RaspberryPi_bcm2711:
+				chip_name = "pinctrl-bcm2711";
+				break;
+			case BoardType::RaspberryPi_bcm2837:
+			case BoardType::RaspberryPi_bcm2836:
+			case BoardType::RaspberryPi_bcm2835:
+				chip_name = "pinctrl-bcm2835";
+				break;
+			case BoardType::Unknown:
+			case BoardType::RaspberryPi_Unknown:
+			default:
+			// Unknown chip
+			break;
+		}
 
-        
+		if (chip_name) {
+			gpiod_chip_iter *iter = gpiod_chip_iter_new();
+			gpiod_chip *tmp_chip = NULL;
+			while (tmp_chip = gpiod_chip_iter_next(iter)) {
+				if (!strcmp(gpiod_chip_label(tmp_chip), chip_name)) {
+					chip = tmp_chip;
+					gpiod_chip_iter_free_noclose(iter);
+					DEBUG_PRINTLN("found and opened chip for device");
+					return 0;
+				}
+			}
 
-        if (chip_name) {
-            gpiod_chip_iter *iter = gpiod_chip_iter_new();
-            gpiod_chip *tmp_chip = NULL;
-            while (tmp_chip = gpiod_chip_iter_next(iter)) {
-                if (!strcmp(gpiod_chip_label(tmp_chip), chip_name)) {
-                    chip = tmp_chip;
-                    gpiod_chip_iter_free_noclose(iter);
-                    DEBUG_PRINTLN("found and opened chip for device");
-                    return 0;
-                }
-            }
+			gpiod_chip_iter_free(iter);
+		} else {
+			chip = gpiod_chip_open_by_name("gpiochip0");
+			if (chip) {
+				DEBUG_PRINTLN("opened gpiochip0");
+				return 0;
+			}
+		}
 
-            gpiod_chip_iter_free(iter);
-        } else {
-            chip = gpiod_chip_open_by_name("gpiochip0");
-            if (chip) {
-                DEBUG_PRINTLN("opened gpiochip0");
-                return 0;
-            }
-        }
-
-        DEBUG_PRINTLN("failed to find and open gpio chip");
-        return -1;
+		DEBUG_PRINTLN("failed to find and open gpio chip");
+		return -1;
 	}
 	return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -109,7 +109,7 @@ uint32_t reboot_timer = 0;
 
 void flow_poll() {
 	#if defined(ESP8266)
-	//if(os.hw_rev>=2) pinModeExt(PIN_SENSOR1, INPUT_PULLUP); // TODO: is this still necessary?
+	if(os.hw_rev>=2) pinMode(PIN_SENSOR1, INPUT_PULLUP); // TODO: is this still necessary?
 	#endif
 
 	ulong curr = millis();
@@ -148,10 +148,10 @@ void flow_poll() {
 		}
 	}
 
-	// Use exponential moving average (alpha=1/2) if flow has been previosuly calculated, otherwise just set the value
+	// Use exponential moving average (alpha=0.2) if flow has been previosuly calculated, otherwise just set the value
 	ulong curr_period = curr - last_flow_rt;
 	if (flow_rt_period > 0) {
-		flow_rt_period = (curr_period + flow_rt_period) >> 1;
+		flow_rt_period = (curr_period  / 5 + flow_rt_period * 4 / 5);
 	} else {
 		flow_rt_period = curr_period;
 	}
@@ -726,8 +726,8 @@ void do_loop()
 
 		#if defined(ESP8266)
 		if(os.hw_rev>=2) {
-			pinModeExt(PIN_SENSOR1, INPUT_PULLUP); // this seems necessary for OS 3.2
-			pinModeExt(PIN_SENSOR2, INPUT_PULLUP);
+			pinMode(PIN_SENSOR1, INPUT_PULLUP); // this seems necessary for OS 3.2
+			pinMode(PIN_SENSOR2, INPUT_PULLUP);
 		}
 		#endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -108,10 +108,6 @@ int32_t flow_rt_period = 0;
 uint32_t reboot_timer = 0;
 
 void flow_poll() {
-	#if defined(ESP8266)
-	if(os.hw_rev>=2) pinMode(PIN_SENSOR1, INPUT_PULLUP); // TODO: is this still necessary?
-	#endif
-
 	ulong curr = millis();
 
 	// Resets counter if timeout occurs
@@ -124,6 +120,14 @@ void flow_poll() {
 	if (flow_rt_period < 0) {
 		last_flow_rt = curr;
 	}
+
+	#if defined(ESP8266)
+	if(os.hw_rev>=2) {
+		pinMode(PIN_SENSOR1, INPUT); // Work-around for PIN_SENSOR1 on OS3.2 and above
+		pinMode(PIN_SENSOR1, INPUT_PULLUP);
+	}
+	#endif
+
 
 	unsigned char curr_flow_state = digitalReadExt(PIN_SENSOR1);
 	if((!prev_flow_state) || curr_flow_state) { // only record on falling edge

--- a/main.cpp
+++ b/main.cpp
@@ -1075,15 +1075,6 @@ void do_loop()
 			os.reboot_dev(REBOOT_CAUSE_TIMER);
 		}
 
-		// real-time flow count
-		static ulong flowcount_rt_start = 0;
-		if (os.iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_FLOW) {
-			// if (curr_time % FLOWCOUNT_RT_WINDOW == 0) {
-			// 	os.flowcount_rt = (flow_count > flowcount_rt_start) ? flow_count - flowcount_rt_start: 0;
-			// 	flowcount_rt_start = flow_count;
-			// }
-		}
-
 		// perform ntp sync
 		// instead of using curr_time, which may change due to NTP sync itself
 		// we use Arduino's millis() method

--- a/main.cpp
+++ b/main.cpp
@@ -1826,8 +1826,8 @@ static void perform_ntp_sync() {
 
 #if !defined(ARDUINO) // main function for RPI/LINUX
 int main(int argc, char *argv[]) {
-    // Disable buffering to work with systemctl journal
-    setvbuf(stdout, NULL, _IOLBF, 0);
+	// Disable buffering to work with systemctl journal
+	setvbuf(stdout, NULL, _IOLBF, 0);
 	printf("Starting OpenSprinkler\n");
 
 	int opt;

--- a/main.cpp
+++ b/main.cpp
@@ -104,7 +104,7 @@ ulong flow_begin, flow_start, flow_stop, flow_gallons, flow_rt_reset, last_flow_
 ulong flow_count = 0;
 unsigned char prev_flow_state = HIGH;
 float flow_last_gpm = 0;
-int32_t flow_rt_period = 0;
+int32_t flow_rt_period = -1;
 uint32_t reboot_timer = 0;
 
 void flow_poll() {

--- a/main.cpp
+++ b/main.cpp
@@ -159,8 +159,8 @@ void flow_poll() {
 	// calculates the flow rate scaled by the window size to simulated a fixed point number
 	if (flow_rt_period > 0) {
 		os.flowcount_rt = (ulong) (FLOWCOUNT_RT_WINDOW * 1000.0 / flow_rt_period);
-		// Sets the timeout to be 3x the last period
-		flow_rt_reset = curr + (curr - last_flow_rt) * 3.0;
+		// Sets the timeout to be 10x the last period
+		flow_rt_reset = curr + (curr - last_flow_rt) * 10.0;
 	} else {
 		os.flowcount_rt = 0;
 		flow_rt_reset = 0;

--- a/opensprinkler_server.cpp
+++ b/opensprinkler_server.cpp
@@ -2041,14 +2041,13 @@ void server_json_debug(OTF_PARAMS_DEF) {
 	(unsigned long)ESP.getFreeHeap());
 	FSInfo fs_info;
 	LittleFS.info(fs_info);
-	bfill.emit_p(PSTR(",\"flash\":$D,\"used\":$D,"), fs_info.totalBytes, fs_info.usedBytes);
+	bfill.emit_p(PSTR(",\"flash\":$D,\"used\":$D,\"devip\":\"$S\","), fs_info.totalBytes, fs_info.usedBytes, (useEth?eth.localIP():WiFi.localIP()).toString().c_str());
 	if(useEth) {
-		bfill.emit_p(PSTR("\"isW5500\":$D}"), eth.isW5500);
+		bfill.emit_p(PSTR("\"isW5500\":$D,\"spi_clock\":$L,\"arp_size\":$D}"), eth.isW5500, ETHER_SPI_CLOCK, ARP_TABLE_SIZE);
 	} else {
 		bfill.emit_p(PSTR("\"rssi\":$D,\"bssid\":\"$S\",\"bssidchl\":\"$O\"}"),
 		WiFi.RSSI(), WiFi.BSSIDstr().c_str(), SOPT_STA_BSSID_CHL);
 	}
-
 /*
 // print out all log files and all files in the main folder with file sizes
 	DEBUG_PRINTLN(F("List Files:"));
@@ -2125,7 +2124,7 @@ const char _url_keys[] PROGMEM =
 	"cu"
 	"ja"
 	"pq"
-    "db"
+	"db"
 #if defined(ARDUINO)
 	//"ff"
 #endif

--- a/opensprinkler_server.cpp
+++ b/opensprinkler_server.cpp
@@ -779,6 +779,11 @@ void server_change_runonce(OTF_PARAMS_DEF) {
 	boolean match_found = false;
 	for(sid=0;sid<os.nstations;sid++) {
 		dur=prog.durations[sid];
+		if(findKeyVal(FKV_SOURCE,tmp_buffer,TMP_BUFFER_SIZE,PSTR("uwt"),true)){
+			if((uint16_t)atol(tmp_buffer)){
+				dur = dur * os.iopts[IOPT_WATER_PERCENTAGE] / 100;
+			}
+		}
 		bid=sid>>3;
 		s=sid&0x07;
 		// if non-zero duration is given

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,7 @@ board_build.flash_mode = dio
 board_build.ldscript = eagle.flash.4m2m.ld
 board_build.f_cpu = 160000000L
 board_build.f_flash = 80000000L
+build_flags = -DARP_TABLE_SIZE=40
 ;build_flags = -DENABLE_DEBUG 
 
 [env:sanguino_atmega1284p]

--- a/testmode.h
+++ b/testmode.h
@@ -1,0 +1,1 @@
+/* TEST MODE parameters */

--- a/utils.cpp
+++ b/utils.cpp
@@ -593,7 +593,7 @@ void urlEncode(char *urlbuf) {
 	urlbuf[newlen] = 0; // Null-terminate the new string
 
 	// Process in reverse to avoid overwriting
-	for (ssize_t i = len - 1, j = newlen - 1; i >= 0; i--) {
+	for (int i = len - 1, j = newlen - 1; i >= 0; i--) {
 		unsigned char c = urlbuf[i];
 		if (c == ' ' || c == '\"' || c == '\'' || c == '<' || c == '>' || c > 127) {
 			static const char hex[] = "0123456789ABCDEF";

--- a/utils.h
+++ b/utils.h
@@ -56,6 +56,7 @@ ulong water_time_resolve(uint16_t v);
 unsigned char water_time_encode_signed(int16_t i);
 int16_t water_time_decode_signed(unsigned char i);
 void urlDecode(char *);
+void urlEncode(char *);
 void strReplaceQuoteBackslash(char *);
 void peel_http_header(char*);
 void strReplace(char *, char c, char r);

--- a/utils.h
+++ b/utils.h
@@ -80,8 +80,8 @@ void str2mac(const char *_str, unsigned char mac[]);
 	const char* get_data_dir();
 	void set_data_dir(const char *new_data_dir);
 	char* get_filename_fullpath(const char *filename);
-    void delay(ulong ms);
-    void delayMicroseconds(ulong us);
+	void delay(ulong ms);
+	void delayMicroseconds(ulong us);
 	void delayMicrosecondsHard(ulong us);
 	ulong millis();
 	ulong micros();
@@ -100,17 +100,17 @@ void str2mac(const char *_str, unsigned char mac[]);
 	in_addr_t get_ip_address(char *iface);
 	#endif
 
-    enum BoardType {
-        Unknown,
-        RaspberryPi_Unknown,
-        RaspberryPi_bcm2712,
-        RaspberryPi_bcm2711,
-        RaspberryPi_bcm2837,
-        RaspberryPi_bcm2836,
-        RaspberryPi_bcm2835,
-    };
+	enum BoardType {
+		Unknown,
+		RaspberryPi_Unknown,
+		RaspberryPi_bcm2712,
+		RaspberryPi_bcm2711,
+		RaspberryPi_bcm2837,
+		RaspberryPi_bcm2836,
+		RaspberryPi_bcm2835,
+	};
 
-    BoardType get_board_type();
+	BoardType get_board_type();
 #endif
 
 #endif // _UTILS_H

--- a/weather.cpp
+++ b/weather.cpp
@@ -166,7 +166,7 @@ void GetWeather() {
 	strcat(ether_buffer, "\r\n\r\n");
 
 	wt_errCode = HTTP_RQT_NOT_RECEIVED;
-	DEBUG_PRINTLN(ether_buffer);
+	DEBUG_PRINT(ether_buffer);
 	int ret = os.send_http_request(host, ether_buffer, getweather_callback_with_peel_header);
 	if(ret!=HTTP_RQT_SUCCESS) {
 		if(wt_errCode < 0) wt_errCode = ret;

--- a/weather.cpp
+++ b/weather.cpp
@@ -146,29 +146,14 @@ void GetWeather() {
 								SOPT_WEATHER_OPTS,
 								(int)os.iopts[IOPT_FW_VERSION]);
 
-	char *src=tmp_buffer+strlen(tmp_buffer);
-	char *dst=tmp_buffer+TMP_BUFFER_SIZE-12;
 
-	char c;
-	// url encode. convert SPACE to %20
-	// copy reversely from the end because we are potentially expanding
-	// the string size
-	while(src!=tmp_buffer) {
-		c = *src--;
-		if(c==' ') {
-			*dst-- = '0';
-			*dst-- = '2';
-			*dst-- = '%';
-		} else {
-			*dst-- = c;
-		}
-	};
-	*dst = *src;
+	urlEncode(tmp_buffer);
 
 	strcpy(ether_buffer, "GET /");
-	strcat(ether_buffer, dst);
-	// because dst is part of tmp_buffer,
-	// must load weather url AFTER dst is copied to ether_buffer
+	strcat(ether_buffer, tmp_buffer);
+	// because we are using tmp_buffer both for encoding the string
+	// and for loading weather url, we will load weather url AFTER
+	// the encoded string has been copied into ether_buffer
 
 	// load weather url to tmp_buffer
 	char *host = tmp_buffer;
@@ -181,6 +166,7 @@ void GetWeather() {
 	strcat(ether_buffer, "\r\n\r\n");
 
 	wt_errCode = HTTP_RQT_NOT_RECEIVED;
+	DEBUG_PRINTLN(ether_buffer);
 	int ret = os.send_http_request(host, ether_buffer, getweather_callback_with_peel_header);
 	if(ret!=HTTP_RQT_SUCCESS) {
 		if(wt_errCode < 0) wt_errCode = ret;

--- a/weather.cpp
+++ b/weather.cpp
@@ -187,18 +187,18 @@ void load_wt_monthly(char* wto) {
 }
 
 void apply_monthly_adjustment(time_os_t curr_time) {
-		// ====== Check monthly water percentage ======
-		if(os.iopts[IOPT_USE_WEATHER]==WEATHER_METHOD_MONTHLY) {
+	// ====== Check monthly water percentage ======
+	if(os.iopts[IOPT_USE_WEATHER]==WEATHER_METHOD_MONTHLY) {
 #if defined(ARDUINO)
-			unsigned char m = month(curr_time)-1;
+		unsigned char m = month(curr_time)-1;
 #else
-			time_os_t ct = curr_time;
-			struct tm *ti = gmtime(&ct);
-			unsigned char m = ti->tm_mon;  // tm_mon ranges from [0,11]
+		time_os_t ct = curr_time;
+		struct tm *ti = gmtime(&ct);
+		unsigned char m = ti->tm_mon;  // tm_mon ranges from [0,11]
 #endif
-			if(os.iopts[IOPT_WATER_PERCENTAGE]!=wt_monthly[m]) {
-				os.iopts[IOPT_WATER_PERCENTAGE]=wt_monthly[m];
-				os.iopts_save();
-			}
+		if(os.iopts[IOPT_WATER_PERCENTAGE]!=wt_monthly[m]) {
+			os.iopts[IOPT_WATER_PERCENTAGE]=wt_monthly[m];
+			os.iopts_save();
 		}
+	}
 }


### PR DESCRIPTION
- **Support for OpenSprinkler v3.4 AC** – a new AC hardware revision featuring a sleek, low-profile enclosure, a power barrel connector for easier power input, an external connector for simplified wired Ethernet module installation, and two additional sensor ports reserved for future use. [Click here to learn more](https://opensprinkler.com/introducing-ac-powered-opensprinkler-v3-4/) about this new hardware version.
- **Improved Flow Meter Handling**: Enhanced reliability when reading low flow count or using flow meters with slow pulse rates.
- **Wired Ethernet Improvement for OpenSprinkler v3**: Increased SPI clock speed and ARP table size to improve performance and stability of the wired Ethernet module.
- **Bug Fixes and Minor Improvements**
     - Fixed issue where run-once program didn't apply watering percentage on first run
     - Corrected HTTP error response code
     - Added User-Agent to HTTP headers
     - Improved URL encoding