### PR TITLE
Make Dockerfile compatible with podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM debian:bookworm-slim AS base
 
-ARG BUILD_VERSION="OSPI"
-
 ########################################
 ## 1st stage compiles OpenSprinkler code
 FROM base AS os-build
+
+ARG BUILD_VERSION="OSPI"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y bash g++ make libmosquittopp-dev libssl-dev libi2c-dev libgpiod-dev libgpiod2 gpiod


### PR DESCRIPTION
I am using podman version 4.9.3 on Linux Mint 22.1 and noticed that BUILD_VERSION resolved to empty.