### PR TITLE
Implement check_network() watchdog for wired Ethernet (ESP8266)

### DIFF
--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -108,6 +108,12 @@
 		inline wl_status_t status() {
 			return (isW5500)?w5500.status():enc28j60.status();
 		}
+		// the lwIP interface behind the active controller. LwipIntfDev hands it
+		// out as const, but etharp_request() takes a mutable netif, so the cast
+		// is kept here rather than at every call site.
+		inline netif* getNetIf() {
+			return (netif*)((isW5500)?w5500.getNetIf():enc28j60.getNetIf());
+		}
 	};
 	extern lwipEth eth;
 	extern bool useEth;

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -239,7 +239,7 @@ If your controller can't connect or stay connected via wired Ethernet, try these
 2. **Disable PoE** (Power-over-Ethernet) on that port: OpenSprinkler’s wired module is **not PoE-compatible**. PoE-enabled port can cause it to malfunction.
 3. **DHCP Setting:** Leave the controller on DHCP, and set a **DHCP reservation** (IP-to-Mac) on your router to assign it a fixed IP. If you must use Static IP, verify **Gateway IP, DNS, Subnet Mask** are all correct and compatible with your router settings.
 4. **Use a dedicated router:** If your wired network is very busy, the most effective solution is to place OpenSprinkler on a dedicated router to isolate it from heavy traffic. 
-5. **Set an auto-reboot program:** If the controller connects initially but doesn't stay connected, a work-around is to set an auto-reboot program (daily or any regular interval of your choice). See [Program Name Annotation](manual.md#program-name-annotations) in the user manual.
+5. **Set an auto-reboot program:** If the controller connects initially but doesn't stay connected, a work-around is to set an auto-reboot program (daily or any regular interval of your choice). See [Program Name Annotation](manual.md#program-name-annotations) in the user manual. On firmware versions that include the wired connection watchdog this is usually unnecessary: the controller checks the connection about every 10 minutes and reboots itself if it stays unreachable, waiting until no program is running.
 
 **<u>For OSPi</u>:** Networking is managed by RPi. Ensure RPi has adequate power (OSPi supplies up to 500 mA. RPi 3/4/5 may need extra power via USB, otherwise network may be unstable).
 

--- a/main.cpp
+++ b/main.cpp
@@ -1890,32 +1890,49 @@ void delete_log(char *name) {
 /** Record the outcome of a network check, and reboot if the connection stays down */
 static void network_check_result(bool ok) {
 	/* Whether an outage may still trigger a reboot. Initialized on first use,
-	 * which is safely after os.begin() has restored last_reboot_cause: if the
-	 * previous boot already ended in a network reboot and the connection has not
-	 * worked since, rebooting again will not fix it either - the cable is simply
-	 * unplugged - so the controller stops trying. */
+	 * which is safely after os.options_setup() has restored last_reboot_cause:
+	 * if the previous boot already ended in a network reboot and the connection
+	 * has not worked since, rebooting again will not fix it either - the cable is
+	 * simply unplugged - so the controller stops trying. */
 	static bool reboot_armed = (os.last_reboot_cause != REBOOT_CAUSE_NETWORK_FAIL);
+	// consecutive failures seen by this watchdog. Kept separate from
+	// status.network_fails so that a single lost probe does not immediately stop
+	// MQTT and the weather query, both of which bail out on that flag.
+	static unsigned char fails = 0;
+	// set while a reboot scheduled *here* is pending, so the cancel path below
+	// never calls off a reboot that something else requested
+	static bool reboot_pending = false;
+	static uint8_t saved_reboot_cause = REBOOT_CAUSE_NONE;
 
 	if (ok) {
 		reboot_armed = true;
-		if (os.status.network_fails == 0) return;
+		if (fails == 0) return;
 		DEBUG_PRINTLN(F("network check recovered"));
+		fails = 0;
 		os.status.network_fails = 0;
-		// call off a reboot that was scheduled for an outage the controller has
-		// since recovered from. Only our own reboot is cancelled here.
-		if (os.status.safe_reboot && os.nvdata.reboot_cause == REBOOT_CAUSE_NETWORK_FAIL) {
+		// call off a reboot that we scheduled for an outage the controller has
+		// since recovered from, and undo the reboot cause we staged for it
+		if (reboot_pending) {
+			reboot_pending = false;
+			os.nvdata.reboot_cause = saved_reboot_cause;
 			os.status.safe_reboot = 0;
 			reboot_timer = 0;
 		}
 		return;
 	}
 
-	if (os.status.network_fails < NETWORK_FAILS_MAX) os.status.network_fails++;
+	if (fails < NETWORK_FAILS_MAX) fails++;
 	DEBUG_PRINT(F("network check failed: "));
-	DEBUG_PRINTLN(os.status.network_fails);
+	DEBUG_PRINTLN(fails);
+	// only report the connection as down once it has failed twice in a row, so a
+	// single dropped ARP reply does not pause MQTT and the weather query
+	if (fails > 1) os.status.network_fails = fails;
 
-	if (os.status.network_fails < NETWORK_FAILS_REBOOT) return;
-	if (!reboot_armed || os.status.safe_reboot) return;
+	if (fails < NETWORK_FAILS_REBOOT) return;
+	if (!reboot_armed) return;
+	// leave any other pending reboot alone - taking over safe_reboot here would
+	// downgrade an unconditional reboot request to an idle-only one
+	if (os.status.safe_reboot || reboot_timer) return;
 
 	/* A wedged Ethernet controller cannot be brought back in place: LwipIntfDev
 	 * has no counterpart to begin(), which registers the netif and installs the
@@ -1924,6 +1941,8 @@ static void network_check_result(bool ok) {
 	 * no program is running (see the safe_reboot handling in do_loop). */
 	DEBUG_PRINTLN(F("network down, scheduling reboot"));
 	reboot_armed = false;
+	reboot_pending = true;
+	saved_reboot_cause = os.nvdata.reboot_cause;
 	os.nvdata.reboot_cause = REBOOT_CAUSE_NETWORK_FAIL;
 	os.status.safe_reboot = 1;
 	reboot_timer = os.now_tz() + REBOOT_NETWORK_FAIL_DELAY;
@@ -1968,14 +1987,19 @@ static void check_network() {
 			network_check_result(true);
 			return;
 		}
+		/* Drop what we know about the gateway first. lwIP keeps a resolved entry
+		 * for ARP_MAXAGE (300s) regardless of whether anything still arrives, so
+		 * without this the lookup below would be answered from the cache and the
+		 * probe would prove nothing. */
+		etharp_cleanup_netif(nif);
 		etharp_request(nif, gw);
 		probe_wait = ARP_PROBE_WAIT;
 		return;
 	}
 
-	/* Collect the probe once the reply has had time to arrive. The gateway's ARP
-	 * entry doubles as the liveness signal: only a received reply refreshes it,
-	 * and lwIP drops it after ARP_MAXAGE. */
+	/* Collect the probe once the reply has had time to arrive. Since the table
+	 * was cleared just before the request went out, an entry can only be there
+	 * if a reply came back in through the receive path. */
 	if (probe_wait && --probe_wait == 0) {
 		netif *nif = eth.getNetIf();
 		eth_addr *mac = NULL;

--- a/main.cpp
+++ b/main.cpp
@@ -1889,19 +1889,11 @@ void delete_log(char *name) {
 #if defined(ESP8266)
 /** Record the outcome of a network check, and reboot if the connection stays down */
 static void network_check_result(bool ok) {
-	/* Whether an outage may still trigger a reboot. Initialized on first use,
-	 * which is safely after os.options_setup() has restored last_reboot_cause:
-	 * if the previous boot already ended in a network reboot and the connection
-	 * has not worked since, rebooting again will not fix it either - the cable is
-	 * simply unplugged - so the controller stops trying. */
+	// if the last boot already ended in a network reboot and nothing has worked
+	// since, another one will not help either. set after options_setup has run
 	static bool reboot_armed = (os.last_reboot_cause != REBOOT_CAUSE_NETWORK_FAIL);
-	// consecutive failures seen by this watchdog. Kept separate from
-	// status.network_fails so that a single lost probe does not immediately stop
-	// MQTT and the weather query, both of which bail out on that flag.
-	static unsigned char fails = 0;
-	// set while a reboot scheduled *here* is pending, so the cancel path below
-	// never calls off a reboot that something else requested
-	static bool reboot_pending = false;
+	static unsigned char fails = 0;  // kept apart from status.network_fails
+	static bool reboot_pending = false;  // set while our own reboot is armed
 	static uint8_t saved_reboot_cause = REBOOT_CAUSE_NONE;
 
 	if (ok) {
@@ -1910,9 +1902,7 @@ static void network_check_result(bool ok) {
 		DEBUG_PRINTLN(F("network check recovered"));
 		fails = 0;
 		os.status.network_fails = 0;
-		// call off a reboot that we scheduled for an outage the controller has
-		// since recovered from, and undo the reboot cause we staged for it
-		if (reboot_pending) {
+		if (reboot_pending) {  // call off the reboot we scheduled
 			reboot_pending = false;
 			os.nvdata.reboot_cause = saved_reboot_cause;
 			os.status.safe_reboot = 0;
@@ -1924,21 +1914,15 @@ static void network_check_result(bool ok) {
 	if (fails < NETWORK_FAILS_MAX) fails++;
 	DEBUG_PRINT(F("network check failed: "));
 	DEBUG_PRINTLN(fails);
-	// only report the connection as down once it has failed twice in a row, so a
-	// single dropped ARP reply does not pause MQTT and the weather query
+	// report down only from the second failure on: mqtt and check_weather stop on this
 	if (fails > 1) os.status.network_fails = fails;
 
 	if (fails < NETWORK_FAILS_REBOOT) return;
 	if (!reboot_armed) return;
-	// leave any other pending reboot alone - taking over safe_reboot here would
-	// downgrade an unconditional reboot request to an idle-only one
-	if (os.status.safe_reboot || reboot_timer) return;
+	if (os.status.safe_reboot || reboot_timer) return;  // leave another reboot alone
 
-	/* A wedged Ethernet controller cannot be brought back in place: LwipIntfDev
-	 * has no counterpart to begin(), which registers the netif and installs the
-	 * packet polling callback, so calling it a second time would corrupt the
-	 * interface list. Rebooting is the only way back, and it is deferred until
-	 * no program is running (see the safe_reboot handling in do_loop). */
+	// LwipIntfDev has no counterpart to begin(), so the interface cannot be
+	// re-initialized in place; rebooting is the only way back
 	DEBUG_PRINTLN(F("network down, scheduling reboot"));
 	reboot_armed = false;
 	reboot_pending = true;
@@ -1956,50 +1940,34 @@ static void network_check_result(bool ok) {
  */
 static void check_network() {
 #if defined(ESP8266)
-	/* Only the wired connection is watched here. In WiFi mode the ESP8266 SDK
-	 * reconnects on its own, which the connection handling in do_loop relies on,
-	 * so this watchdog stays out of the way there. */
-	if (!useEth) return;
+	if (!useEth) return;  // in WiFi mode the SDK handles re-connect itself
 
-	// seconds left before an outstanding probe is collected, 0 if none is in
-	// flight. do_loop calls this function once per second, which is also the
-	// cadence req_network is raised at.
-	static unsigned char probe_wait = 0;
+	static unsigned char probe_wait = 0;  // seconds left before collecting the probe
 
 	if (os.status.req_network) {
 		os.status.req_network = 0;
 
-		/* Stage 1: link state and IP address. This catches an unplugged cable
-		 * and an expired DHCP lease, but not a stalled receive path, which
-		 * leaves both of them looking healthy. */
+		// link and address. a stalled receive path leaves both looking healthy
 		if (!eth.connected()) {
 			network_check_result(false);
 			return;
 		}
 
-		/* Stage 2: ask the gateway to identify itself. Its answer has to travel
-		 * through exactly the receive path that stage 1 cannot vouch for. With
-		 * no gateway configured there is nothing to ask, so stage 1 stands on
-		 * its own. */
 		netif *nif = eth.getNetIf();
 		const ip4_addr_t *gw = netif_ip4_gw(nif);
-		if (ip4_addr_isany(gw)) {
+		if (ip4_addr_isany(gw)) {  // nothing to ask, stage 1 stands on its own
 			network_check_result(true);
 			return;
 		}
-		/* Drop what we know about the gateway first. lwIP keeps a resolved entry
-		 * for ARP_MAXAGE (300s) regardless of whether anything still arrives, so
-		 * without this the lookup below would be answered from the cache and the
-		 * probe would prove nothing. */
+		// drop the cached entry first: lwIP keeps a resolved one for ARP_MAXAGE
+		// whether or not anything still arrives, and would answer from cache
 		etharp_cleanup_netif(nif);
 		etharp_request(nif, gw);
 		probe_wait = ARP_PROBE_WAIT;
 		return;
 	}
 
-	/* Collect the probe once the reply has had time to arrive. Since the table
-	 * was cleared just before the request went out, an entry can only be there
-	 * if a reply came back in through the receive path. */
+	// an entry can only be here if a reply came back in through the receive path
 	if (probe_wait && --probe_wait == 0) {
 		netif *nif = eth.getNetIf();
 		eth_addr *mac = NULL;

--- a/main.cpp
+++ b/main.cpp
@@ -34,6 +34,7 @@
 
 #if defined(ESP8266)
 	#include <Arduino.h>
+	#include <lwip/etharp.h>
 	ESP8266WebServer *update_server = NULL;
 	DNSServer *dns = NULL;
 	ENC28J60lwIP enc28j60(PIN_ETHER_CS); // ENC28J60 lwip for wired Ether
@@ -70,6 +71,10 @@ void manual_start_program(unsigned char, unsigned char, unsigned char, unsigned 
 #define CHECK_WEATHER_SUCCESS_TIMEOUT 86400L // Weather check success interval (in seconds)
 #define LCD_BACKLIGHT_TIMEOUT     15    // LCD backlight timeout (in seconds))
 #define PING_TIMEOUT              200   // Ping test timeout (in ms)
+#define ARP_PROBE_WAIT            2     // how long to wait for the gateway's ARP reply (in seconds)
+#define NETWORK_FAILS_MAX         6     // clamp for network_fails (it is a 3-bit field)
+#define NETWORK_FAILS_REBOOT      3     // consecutive failed checks before rebooting
+#define REBOOT_NETWORK_FAIL_DELAY 5     // grace period before a network reboot (in seconds)
 #define UI_STATE_MACHINE_INTERVAL 50    // how often does ui_state_machine run (in ms)
 #define CLIENT_READ_TIMEOUT       5     // client read timeout (in seconds)
 #define DHCP_CHECKLEASE_INTERVAL  3600L // DHCP check lease interval (in seconds)
@@ -1881,14 +1886,105 @@ void delete_log(char *name) {
 #endif
 }
 
+#if defined(ESP8266)
+/** Record the outcome of a network check, and reboot if the connection stays down */
+static void network_check_result(bool ok) {
+	/* Whether an outage may still trigger a reboot. Initialized on first use,
+	 * which is safely after os.begin() has restored last_reboot_cause: if the
+	 * previous boot already ended in a network reboot and the connection has not
+	 * worked since, rebooting again will not fix it either - the cable is simply
+	 * unplugged - so the controller stops trying. */
+	static bool reboot_armed = (os.last_reboot_cause != REBOOT_CAUSE_NETWORK_FAIL);
+
+	if (ok) {
+		reboot_armed = true;
+		if (os.status.network_fails == 0) return;
+		DEBUG_PRINTLN(F("network check recovered"));
+		os.status.network_fails = 0;
+		// call off a reboot that was scheduled for an outage the controller has
+		// since recovered from. Only our own reboot is cancelled here.
+		if (os.status.safe_reboot && os.nvdata.reboot_cause == REBOOT_CAUSE_NETWORK_FAIL) {
+			os.status.safe_reboot = 0;
+			reboot_timer = 0;
+		}
+		return;
+	}
+
+	if (os.status.network_fails < NETWORK_FAILS_MAX) os.status.network_fails++;
+	DEBUG_PRINT(F("network check failed: "));
+	DEBUG_PRINTLN(os.status.network_fails);
+
+	if (os.status.network_fails < NETWORK_FAILS_REBOOT) return;
+	if (!reboot_armed || os.status.safe_reboot) return;
+
+	/* A wedged Ethernet controller cannot be brought back in place: LwipIntfDev
+	 * has no counterpart to begin(), which registers the netif and installs the
+	 * packet polling callback, so calling it a second time would corrupt the
+	 * interface list. Rebooting is the only way back, and it is deferred until
+	 * no program is running (see the safe_reboot handling in do_loop). */
+	DEBUG_PRINTLN(F("network down, scheduling reboot"));
+	reboot_armed = false;
+	os.nvdata.reboot_cause = REBOOT_CAUSE_NETWORK_FAIL;
+	os.status.safe_reboot = 1;
+	reboot_timer = os.now_tz() + REBOOT_NETWORK_FAIL_DELAY;
+}
+#endif
+
 /** Perform network check
- * This function pings the router
- * to check if it's still online.
- * If not, it re-initializes Ethernet controller.
+ * On a wired connection, this verifies the link and address, then asks the
+ * router for its MAC address to confirm that packets still arrive.
+ * If the connection stays down, the controller reboots once it is idle.
  */
 static void check_network() {
-	// TODO:
-	// nothing to do for other platforms
+#if defined(ESP8266)
+	/* Only the wired connection is watched here. In WiFi mode the ESP8266 SDK
+	 * reconnects on its own, which the connection handling in do_loop relies on,
+	 * so this watchdog stays out of the way there. */
+	if (!useEth) return;
+
+	// seconds left before an outstanding probe is collected, 0 if none is in
+	// flight. do_loop calls this function once per second, which is also the
+	// cadence req_network is raised at.
+	static unsigned char probe_wait = 0;
+
+	if (os.status.req_network) {
+		os.status.req_network = 0;
+
+		/* Stage 1: link state and IP address. This catches an unplugged cable
+		 * and an expired DHCP lease, but not a stalled receive path, which
+		 * leaves both of them looking healthy. */
+		if (!eth.connected()) {
+			network_check_result(false);
+			return;
+		}
+
+		/* Stage 2: ask the gateway to identify itself. Its answer has to travel
+		 * through exactly the receive path that stage 1 cannot vouch for. With
+		 * no gateway configured there is nothing to ask, so stage 1 stands on
+		 * its own. */
+		netif *nif = eth.getNetIf();
+		const ip4_addr_t *gw = netif_ip4_gw(nif);
+		if (ip4_addr_isany(gw)) {
+			network_check_result(true);
+			return;
+		}
+		etharp_request(nif, gw);
+		probe_wait = ARP_PROBE_WAIT;
+		return;
+	}
+
+	/* Collect the probe once the reply has had time to arrive. The gateway's ARP
+	 * entry doubles as the liveness signal: only a received reply refreshes it,
+	 * and lwIP drops it after ARP_MAXAGE. */
+	if (probe_wait && --probe_wait == 0) {
+		netif *nif = eth.getNetIf();
+		eth_addr *mac = NULL;
+		const ip4_addr_t *ip = NULL;
+		network_check_result(etharp_find_addr(nif, netif_ip4_gw(nif), &mac, &ip) >= 0);
+	}
+#else
+	// nothing to do for other platforms: the OS manages the network
+#endif
 }
 
 /** Perform NTP sync */

--- a/main.cpp
+++ b/main.cpp
@@ -1887,14 +1887,18 @@ void delete_log(char *name) {
 }
 
 #if defined(ESP8266)
+// watchdog state, reported by /db so its behaviour can be observed from outside
+unsigned char network_check_fails = 0;
+bool network_reboot_pending = false;
+
 /** Record the outcome of a network check, and reboot if the connection stays down */
 static void network_check_result(bool ok) {
 	// if the last boot already ended in a network reboot and nothing has worked
 	// since, another one will not help either. set after options_setup has run
 	static bool reboot_armed = (os.last_reboot_cause != REBOOT_CAUSE_NETWORK_FAIL);
-	static unsigned char fails = 0;  // kept apart from status.network_fails
-	static bool reboot_pending = false;  // set while our own reboot is armed
 	static uint8_t saved_reboot_cause = REBOOT_CAUSE_NONE;
+	unsigned char &fails = network_check_fails;  // kept apart from status.network_fails
+	bool &reboot_pending = network_reboot_pending;
 
 	if (ok) {
 		reboot_armed = true;

--- a/opensprinkler_server.cpp
+++ b/opensprinkler_server.cpp
@@ -3063,7 +3063,10 @@ void server_json_debug(OTF_PARAMS_DEF) {
 	LittleFS.info(fs_info);
 	bfill.emit_p(PSTR(",\"flash\":$D,\"used\":$D,\"devip\":\"$S\","), fs_info.totalBytes, fs_info.usedBytes, (useEth?eth.localIP():WiFi.localIP()).toString().c_str());
 	if(useEth) {
-		bfill.emit_p(PSTR("\"isW5500\":$D,\"spi_clock\":$L,\"arp_size\":$D}"), eth.isW5500, ETHER_SPI_CLOCK, ARP_TABLE_SIZE);
+		extern unsigned char network_check_fails;
+		extern bool network_reboot_pending;
+		bfill.emit_p(PSTR("\"isW5500\":$D,\"spi_clock\":$L,\"arp_size\":$D,\"ethlink\":$D,\"netfails\":$D,\"netreboot\":$D}"),
+		eth.isW5500, ETHER_SPI_CLOCK, ARP_TABLE_SIZE, eth.connected()?1:0, network_check_fails, network_reboot_pending?1:0);
 	} else {
 		bfill.emit_p(PSTR("\"rssi\":$D,\"bssid\":\"$S\",\"bssidchl\":\"$O\"}"),
 		WiFi.RSSI(), WiFi.BSSIDstr().c_str(), SOPT_STA_BSSID_CHL);


### PR DESCRIPTION
## Problem

On ESP8266 a wired controller has no recovery path at all. In WiFi mode the SDK reconnects on its own and `do_loop()` explicitly relies on that (`// WiFi disconnected, ESP8266 will handle re-connect`), but nothing re-establishes a wired connection: `start_ether()` runs exactly once, from `do_setup()`. That is why `docs/docs/troubleshooting.md` currently has to recommend setting up an auto-reboot program as the workaround for "connects initially but doesn't stay connected".

`check_network()` is the function meant to handle this. On ESP8266 it has been an empty stub since the 2.1.7 port (`7596d78`, 2017). The ping-and-reinitialize implementation it replaced was guarded by `#if defined(ARDUINO) && !defined(ESP8266)`, so the ESP8266 build never got one. Its doc comment still describes that older implementation.

The supporting scaffolding is all still in place and currently unused:

- `os.status.req_network` is raised every `CHECK_NETWORK_INTERVAL` in `do_loop()` and never read anywhere.
- `os.status.network_fails`, a 3-bit field sized for the old `1 << network_fails` backoff, is only ever written in `do_setup()`.
- `REBOOT_CAUSE_NETWORK_FAIL` was introduced in 2019 (`acbd2ca`) and used by the AVR variant of `check_network()`; it has had no user since AVR support was dropped in `39db235` (2025-11-17).
- `PING_TIMEOUT` in `main.cpp` is likewise unused.

## What this changes

`check_network()` is implemented for ESP8266, driven by the `req_network` flag that already exists.

It runs only when `useEth` is set, so WiFi behaviour is unchanged. That keeps the risk away from the vast majority of installations.

The check has two stages:

1. `eth.connected()` verifies link state and IP address. This catches an unplugged cable and an expired DHCP lease.
2. An ARP request to the gateway, collected two seconds later. This is what stage 1 cannot do: a stalled receive path leaves both link and address intact, so only an actual reply proves that frames still arrive. The gateway's cache entry is dropped via `etharp_cleanup_netif()` immediately before the request, because lwIP would otherwise keep a resolved entry for `ARP_MAXAGE` (300 s) and answer the lookup from cache, which would prove nothing.

After three consecutive failures (`NETWORK_FAILS_REBOOT`), which is 20 to 30 minutes at the existing 601 s interval depending on where the outage falls in the cycle, the controller reboots through the `safe_reboot` mechanism that is already there. It waits until no program is running and none is due within the next minute.

The watchdog keeps its own failure counter and only mirrors it into `os.status.network_fails` from the second consecutive failure onwards, so a single dropped ARP reply does not pause MQTT and the weather query (both bail out on that flag).

If some other reboot is already pending, the watchdog leaves it alone rather than taking over `safe_reboot`. Otherwise an unconditional `:>reboot_now` would be silently downgraded to an idle-only reboot.

On wired controllers `/db` gains three fields so the watchdog can be observed without waiting for a restart: `ethlink` (link and address per `eth.connected()`), `netfails` (consecutive failures) and `netreboot` (a reboot is armed). Without them the deferred-reboot behaviour cannot be told apart from the watchdog never having fired, which is what made the first hardware test unusable.

## Why reboot instead of re-initializing

`LwipIntfDev` in core 3.1.2 has no `end()`: `begin()` (`LwipIntfDev.h:179`) adds the netif via `netif_add()` (line 229) and registers a recurrent polling callback (line 276), and `config()` refuses to run once `_started` is set (line 149). A second `begin()` would add the same netif again and register a second polling callback. A chip-level reset below lwIP would be conceivable for the W5500 (`Wiznet5500::end()` exists) but not for the ENC28J60, which has none. A controlled reboot is the one recovery that works for both.

A controller that has already rebooted for a network failure will not reboot again until the connection has worked at least once, so an unplugged cable cannot put it into a reboot loop.

## Relation to #220

#220 addresses the same gap and I would rather not duplicate the intent behind it. This PR differs in scope deliberately: no new library dependency (#220 pulls in `bluemurder/esp8266-ping`), `DEBUG_` macros instead of `Serial.printf`, and nothing outside this one function.

## Testing

`pio run -e os3x_esp8266` builds clean. RAM 50.8 %, flash 58.5 %.

Verified on an OpenSprinkler 3.2 AC (hw_rev 2, ENC28J60) running over wired Ethernet, by pulling the cable and watching what the controller did:

| | |
|---|---|
| Cable pulled | 19:58:02 |
| Reboot | 20:21:36, i.e. 23 min later |
| Cable back in | 21:33:51 |
| `lrbtc` afterwards | 9 (`REBOOT_CAUSE_NETWORK_FAIL`) |
| `netfails` afterwards | 6 |
| `netreboot` afterwards | 0 |

23 minutes matches three failed checks at the existing 601 s interval, with the first one falling a few minutes after the cable came out. The reboot cause is one only this code sets.

The controller then ran for another 72 minutes with the cable still out, which is seven further check intervals. `netfails` shows the counter clamped at `NETWORK_FAILS_MAX` and `netreboot` shows no second reboot was armed, so the interlock against reboot loops does what it is meant to. Watering continued normally throughout the outage.

Before this, a first attempt at the same test could not be evaluated at all: a program was running for its whole duration, so `safe_reboot` correctly deferred the reboot, and from the outside that is indistinguishable from the watchdog never having fired. That is what the `/db` fields are for.

The `#else` branch for OSPi/Linux stays an empty function, so those targets are unaffected.

## Notes

`ARP_PROBE_WAIT` relies on `check_network()` being called once per second from `do_loop()`, which is also the cadence at which `req_network` is raised. Happy to switch this to a `millis()` comparison if you would rather not depend on that.

`etharp_cleanup_netif()` clears the whole ARP table of the wired interface, not just the gateway entry; lwIP exposes no narrower call. At one probe per 601 s the extra ARP traffic is negligible, but I am happy to revisit if you would rather not touch the table at all.
