### PR TITLE
Check the wired link before handing the interface to lwIP

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -461,6 +461,22 @@ unsigned char OpenSprinkler::start_ether() {
 	}
 
 	load_hardware_mac((uint8_t*)tmp_buffer, true);
+
+	/* Bring up the chip on its own first and wait for the link there. eth.begin()
+	 * registers the netif with lwIP, starts its DHCP client and installs the
+	 * packet polling callback, and none of that can be taken back: LwipIntfDev
+	 * has no end(). Committing to it before we know a cable is attached is what
+	 * used to leave a second, invisible interface running after a fallback. */
+	if(!eth.rawBegin((uint8_t*)tmp_buffer)) return 0;
+	lcd_print_line_clear_pgm(PSTR("Wait for link"), 1);
+	uint32_t linkout = millis()+ETHER_LINK_TIMEOUT;
+	while(!eth.rawLinked() && (int32_t)((uint32_t)millis()-linkout)<0) { delay(250); }
+	if(!eth.rawLinked() && !iopts[IOPT_FORCE_WIRED]) {
+		// no cable and the user has not asked us to insist: leave lwIP untouched
+		DEBUG_PRINTLN(F("no wired link, falling back to WiFi"));
+		return 0;
+	}
+
 	if (iopts[IOPT_USE_DHCP]==0) { // config static IP before calling eth.begin
 		IPAddress staticip(iopts+IOPT_STATIC_IP1);
 		IPAddress gateway(iopts+IOPT_GATEWAY_IP1);

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -470,6 +470,7 @@ unsigned char OpenSprinkler::start_ether() {
 	}
 	eth.setDefault();
 	if(!eth.begin((uint8_t*)tmp_buffer))	return 0;
+	eth_started = true;
 	lcd_print_line_clear_pgm(PSTR("Start wired link"), 1);
 	lcd_print_line_clear_pgm(eth.isW5500 ? PSTR("  [w5500]    ") : PSTR(" [enc28j60]  "), 2);
 
@@ -493,9 +494,14 @@ unsigned char OpenSprinkler::start_ether() {
 			iopts_save();
 		}
 		return 1;
+	} else if (iopts[IOPT_FORCE_WIRED]) {
+		return 1;
 	} else {
-		// if wired connection has failed at this point, return depending on whether the user wants to force wired
-		return (iopts[IOPT_FORCE_WIRED] ? 1 : 0);
+		// falling back to WiFi, but the wired interface stays up and keeps its
+		// DHCP client running: it may still pick up an address later and answer
+		// on it, without the controller knowing about it
+		DEBUG_PRINTLN(F("wired link failed, falling back to WiFi with the netif still up"));
+		return 0;
 	}
 }
 
@@ -3068,14 +3074,21 @@ void OpenSprinkler::config_ip() {
 }
 
 void OpenSprinkler::save_wifi_ip() {
-	// todo: handle wired ethernet
-	if(iopts[IOPT_USE_DHCP] && WiFi.status() == WL_CONNECTED) {
+	if(!iopts[IOPT_USE_DHCP]) return;
+	if(useEth) {
+		if(!eth.connected()) return;
+		memcpy(iopts+IOPT_STATIC_IP1, &(eth.localIP()[0]), 4);
+		memcpy(iopts+IOPT_GATEWAY_IP1, &(eth.gatewayIP()[0]),4);
+		memcpy(iopts+IOPT_DNS_IP1, &(eth.dnsIP()[0]), 4);
+		memcpy(iopts+IOPT_SUBNET_MASK1, &(eth.subnetMask()[0]), 4);
+	} else {
+		if(WiFi.status() != WL_CONNECTED) return;
 		memcpy(iopts+IOPT_STATIC_IP1, &(WiFi.localIP()[0]), 4);
 		memcpy(iopts+IOPT_GATEWAY_IP1, &(WiFi.gatewayIP()[0]),4);
 		memcpy(iopts+IOPT_DNS_IP1, &(WiFi.dnsIP()[0]), 4);
 		memcpy(iopts+IOPT_SUBNET_MASK1, &(WiFi.subnetMask()[0]), 4);
-		iopts_save();
 	}
+	iopts_save();
 }
 
 void OpenSprinkler::detect_expanders() {

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -108,11 +108,21 @@
 		inline wl_status_t status() {
 			return (isW5500)?w5500.status():enc28j60.status();
 		}
+		// Bring up the controller chip only, without registering anything with
+		// lwIP. LwipIntfDev inherits publicly from the driver, so the raw begin()
+		// is reachable and can be called before we commit to the interface.
+		inline boolean rawBegin(const uint8_t *macAddress) {
+			return (isW5500)?w5500.Wiznet5500::begin(macAddress):enc28j60.ENC28J60::begin(macAddress);
+		}
+		// Link state straight from the chip, usable once rawBegin() has run
+		inline bool rawLinked() {
+			return (isW5500)?w5500.Wiznet5500::isLinked():enc28j60.ENC28J60::isLinked();
+		}
 	};
 	extern lwipEth eth;
 	extern bool useEth;
-	// eth.begin() succeeded, so the netif stays registered even when the
-	// controller falls back to WiFi. LwipIntfDev has no way to undo it.
+	// eth.begin() succeeded, so the netif stays registered even if the controller
+	// later falls back to WiFi. LwipIntfDev has no way to undo it.
 	extern bool eth_started;
 #else
 	// OSPI/Linux specific

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -111,6 +111,9 @@
 	};
 	extern lwipEth eth;
 	extern bool useEth;
+	// eth.begin() succeeded, so the netif stays registered even when the
+	// controller falls back to WiFi. LwipIntfDev has no way to undo it.
+	extern bool eth_started;
 #else
 	// OSPI/Linux specific
 #endif

--- a/defines.h
+++ b/defines.h
@@ -375,6 +375,7 @@ enum {
 
 	#define PIN_ETHER_CS       16 // Ethernet CS (chip select pin) is 16 on OS 3.2 and above
 	#define ETHER_SPI_CLOCK    10000000L // SPI clock for Ethernet (e.g. 10MHz)
+	#define ETHER_LINK_TIMEOUT 8000L // how long to wait for the wired link before giving up (in ms)
 
 	/* To accommodate different OS30 versions, we use software defines pins */
 	extern unsigned char PIN_BUTTON_1;

--- a/main.cpp
+++ b/main.cpp
@@ -40,6 +40,7 @@
 	Wiznet5500lwIP w5500(PIN_ETHER_CS); // W5500 lwip for wired Ether
 	lwipEth eth;
 	bool useEth = false; // tracks whether we are using WiFi or wired Ether connection
+	bool eth_started = false;
 	uint32_t getNtpTime();
 #else // header and defs for RPI/Linux
 	#include <dirent.h>

--- a/opensprinkler_server.cpp
+++ b/opensprinkler_server.cpp
@@ -1183,7 +1183,8 @@ void server_json_controller_main(OTF_PARAMS_DEF) {
 	}
 
 #if defined(ESP8266)
-	bfill.emit_p(PSTR("\"RSSI\":$D,"), (int16_t)WiFi.RSSI());
+	// RSSI is meaningless on a wired connection, where the radio is off
+	if(!useEth) bfill.emit_p(PSTR("\"RSSI\":$D,"), (int16_t)WiFi.RSSI());
 	bfill.emit_p(PSTR("\"apdv\":$D,"), os.actual_pd_voltage);
 #endif
 
@@ -3064,6 +3065,10 @@ void server_json_debug(OTF_PARAMS_DEF) {
 	bfill.emit_p(PSTR(",\"flash\":$D,\"used\":$D,\"devip\":\"$S\","), fs_info.totalBytes, fs_info.usedBytes, (useEth?eth.localIP():WiFi.localIP()).toString().c_str());
 	if(useEth) {
 		bfill.emit_p(PSTR("\"isW5500\":$D,\"spi_clock\":$L,\"arp_size\":$D}"), eth.isW5500, ETHER_SPI_CLOCK, ARP_TABLE_SIZE);
+	} else if(eth_started) {
+		// on WiFi, but the wired netif is still registered and may hold its own address
+		bfill.emit_p(PSTR("\"ethip\":\"$S\",\"rssi\":$D,\"bssid\":\"$S\",\"bssidchl\":\"$O\"}"),
+		eth.localIP().toString().c_str(), WiFi.RSSI(), WiFi.BSSIDstr().c_str(), SOPT_STA_BSSID_CHL);
 	} else {
 		bfill.emit_p(PSTR("\"rssi\":$D,\"bssid\":\"$S\",\"bssidchl\":\"$O\"}"),
 		WiFi.RSSI(), WiFi.BSSIDstr().c_str(), SOPT_STA_BSSID_CHL);


### PR DESCRIPTION
Three places where the wired connection is not handled the way the WiFi one is.

## `save_wifi_ip()` never stored a wired address

The function carried a `// todo: handle wired ethernet` and only ever ran for WiFi, so on a wired controller the stored address options stayed at whatever `start_ether()` wrote once at boot. If DHCP hands out a different address later, the values in Edit Options drift away from reality. It now takes the values from whichever interface is actually in use.

## `/jc` reported an RSSI on wired controllers

`useEth` implies `WiFi.mode(WIFI_OFF)`, so the reported value is whatever the radio last left behind. The field is now omitted on a wired connection rather than filled with a meaningless number. Clients that read it should already tolerate its absence, since it does not exist on OSPi builds either, but this is an API change worth pointing out.

## The wired interface could stay up after a fallback to WiFi

`start_ether()` called `eth.begin()` before it knew whether a cable was attached. That call registers the netif with lwIP, starts its DHCP client and installs the packet polling callback, and none of it can be taken back: `LwipIntfDev` in core 3.1.2 has no `end()`, and `config()` refuses to run once `_started` is set.

So when the link then failed and `fwire` was 0, the controller moved on to WiFi while the wired interface kept running. If a lease arrived after the timeout it answered on that address too, with `useEth` saying it was a WiFi device. I hit this on an OS 3.2 with an ENC28J60: reachable on two addresses at once, one per interface, with only the WiFi one reported in `/db` and on the LCD.

The fix is to ask the chip before involving lwIP. `LwipIntfDev` inherits publicly from the driver, so the raw driver is reachable:

```c
if(!eth.rawBegin(mac)) return 0;                    // chip only, lwIP untouched
while(!eth.rawLinked() && !timeout) delay(250);     // link straight from the PHY
if(!eth.rawLinked() && !fwire) return 0;            // clean fallback

if(!eth.begin(mac)) return 0;                       // only now: netif + DHCP
```

`rawBegin()` runs `ENC28J60::begin()` or `Wiznet5500::begin()`, `rawLinked()` reads `isLinked()`. Both are public on the driver classes, so this needs no change to the core.

Both settings keep an honest meaning. `fwire=1` waits for the link and takes the interface either way. `fwire=0` falls back to WiFi without ever creating a second interface.

One case remains: link up, but DHCP failing, with `fwire=0`. The netif is registered by then and cannot be removed, so `eth_started` still records it and `/db` reports the wired address under `ethip`. That is now a rare corner rather than the normal path.

Startup also gets shorter. The old loop waited up to 60 s for `eth.connected()`, which is link and address together. The link alone now gets `ETHER_LINK_TIMEOUT` (8 s) and DHCP keeps the remainder.

## Testing

`pio run -e os3x_esp8266` builds clean, RAM 50.8 %, flash 58.5 %.

Both paths were checked on an OS 3.2 AC with an ENC28J60.

**Cable attached, `fwire=1`.** The controller comes up on the wired interface as before, so the added link check does not get in the way of the normal path. `/jc` no longer carries an RSSI field, and the stored address options follow the wired DHCP lease.

**No cable, `fwire=0`.** The controller falls back to WiFi as intended. The point of the change is what happens next: after plugging the cable back in, the wired address stays silent.

```
$ ping 192.168.1.90
3 packets transmitted, 0 packets received, 100.0% packet loss

$ arp -n 192.168.1.90
? (192.168.1.90) at (incomplete) on en0

$ # full ARP sweep of the subnet: the wired MAC does not appear at all
```

`incomplete` means nobody answered the ARP request, and the interface's MAC is absent from the subnet, so the interface is not merely without an address, it is inactive. Before this change the same sequence left that address answering on its own DHCP lease while `useEth` reported a WiFi device, which is how the problem was found.

Related to #421, which adds the watchdog that recovers a wired connection once it is lost. The two do not overlap in code.
