### PR TITLE
Accept brace-wrapped values for nested string options

### DIFF
--- a/opensprinkler_server.cpp
+++ b/opensprinkler_server.cpp
@@ -1487,6 +1487,7 @@ void server_change_options(OTF_PARAMS_DEF)
 	}
 	uint8_t keyfound = 0;
 	if(findKeyVal(FKV_SOURCE, tmp_buffer, TMP_BUFFER_SIZE, PSTR("wto"), true)) {
+		strStripOuterBraces(tmp_buffer);
 		if (os.sopt_save(SOPT_WEATHER_OPTS, tmp_buffer)) {
 			os.sopt_load(SOPT_WEATHER_OPTS, tmp_buffer+1); // make room for the leading '{'
 			parse_wto(tmp_buffer); // parse wto
@@ -1505,6 +1506,7 @@ void server_change_options(OTF_PARAMS_DEF)
 
 	keyfound = 0;
 	if (findKeyVal(FKV_SOURCE, tmp_buffer, TMP_BUFFER_SIZE, PSTR("otc"), true, &keyfound)) {
+		strStripOuterBraces(tmp_buffer);
 		os.sopt_save(SOPT_OTC_OPTS, tmp_buffer);
 	} else if (keyfound) {
 		tmp_buffer[0]=0;
@@ -1513,6 +1515,7 @@ void server_change_options(OTF_PARAMS_DEF)
 
 	keyfound = 0;
 	if(findKeyVal(FKV_SOURCE, tmp_buffer, TMP_BUFFER_SIZE, PSTR("mqtt"), true, &keyfound)) {
+		strStripOuterBraces(tmp_buffer);
 		os.sopt_save(SOPT_MQTT_OPTS, tmp_buffer);
 		os.status.req_mqtt_restart = true;
 	} else if (keyfound) {
@@ -1523,6 +1526,7 @@ void server_change_options(OTF_PARAMS_DEF)
 
 	keyfound = 0;
 	if(findKeyVal(FKV_SOURCE, tmp_buffer, TMP_BUFFER_SIZE, PSTR("email"), true, &keyfound)) {
+		strStripOuterBraces(tmp_buffer);
 		os.sopt_save(SOPT_EMAIL_OPTS, tmp_buffer);
 	} else if (keyfound) {
 		tmp_buffer[0]=0;

--- a/utils.cpp
+++ b/utils.cpp
@@ -730,6 +730,19 @@ void strReplaceQuoteBackslash(char *buf) {
 	strReplace(buf, '\\', '/');
 }
 
+// Nested-object string options (wto, mqtt, otc, email) are stored WITHOUT their
+// enclosing braces: the JSON emitters print them as "key":{$O}, and parse_wto()
+// adds the braces back before deserializing. A client that sends a complete
+// JSON object would otherwise have its braces stored too, producing "key":{{..}}
+// and making /ja unparseable. Accept either form by removing one matching pair.
+void strStripOuterBraces(char *buf) {
+	size_t len = strlen(buf);
+	if (len >= 2 && buf[0] == '{' && buf[len-1] == '}') {
+		memmove(buf, buf+1, len-2);
+		buf[len-2] = 0;
+	}
+}
+
 static const unsigned char month_days[] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
 bool isLastDayofMonth(unsigned char month, unsigned char day) {

--- a/utils.h
+++ b/utils.h
@@ -93,6 +93,7 @@ int16_t water_time_decode_signed(unsigned char i);
 void urlDecode(char *);
 void urlEncode(char *);
 void strReplaceQuoteBackslash(char *);
+void strStripOuterBraces(char *);
 void peel_http_header(char*);
 void strReplace(char *, char c, char r);
 


### PR DESCRIPTION
Addresses #423.

## What this changes

The nested-object string options (`wto`, `mqtt`, `otc`, `email`) are stored without their enclosing braces — the emitters print them as `"key":{$O}`, `parse_wto()` writes the braces back before deserializing, and `server_change_options()` loads into `tmp_buffer+1` specifically to reserve room for the leading brace. A client that sends a complete JSON object therefore has its braces stored as part of the value, and `/ja` then emits `"wto":{{...}}`, which no longer parses.

This adds `strStripOuterBraces()` alongside the other string helpers in `utils.cpp` and calls it at the four `/co` save sites, so either encoding is accepted.

## Why it should be safe

Values written in the documented form are untouched: an object body begins with a quote, never a brace, so the strip is a no-op for existing callers. Only one matching outer pair is removed, so a nested object inside the value survives. The operation only ever shortens the string, so there is no buffer risk — and it frees the two spare bytes `parse_wto()` needs when it appends its closing brace.

## Testing

Built the OSPI target in Docker and exercised `/co` against a running instance, comparing an unpatched build with a patched one on the same inputs:

| Input | Before | After |
| --- | --- | --- |
| `wto={"h":20,"t":50}` | `"wto":{{"h":20,"t":50}}`, `/ja` fails to parse | parses, `{"h":20,"t":50}` |
| `wto="h":30,"t":60` | parses | parses, unchanged |
| `wto={}` | `"wto":{{}}`, fails to parse | parses, `{}` |
| `mqtt={"en":1,"host":"a"}` | fails to parse | parses, `{"en":1,"host":"a"}` |
| `mqtt="en":0,"host":"b"` | parses | parses, unchanged |
| `mqtt={"en":1,"x":{"y":2}}` | — | parses, inner object intact |

I have only exercised the OSPI/Linux build; I have not flashed this to an AVR or ESP target.

## One design question

I took the lenient route — accept either form — on the assumption that silently repairing existing broken clients is preferable. Rejecting brace-wrapped input with an error would surface the mistake more loudly and is a small change to the same helper. Happy to switch if you would rather it be strict, or to close this in favour of a documentation note if that is the direction you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
