### PR TITLE
fix: correct major revision example in firmware update warning (2.2.2 to 3.0.0)

### DIFF
--- a/html/update.html
+++ b/html/update.html
@@ -111,7 +111,7 @@
         </div>
 
         <div class="warning-box">
-            <b>IMPORTANT:</b> Firmware updates across major revisions (e.g., from 2.2.1 to 2.2.2) will trigger a factory reset. Please save a copy of your current configurations before proceeding.
+            <b>IMPORTANT:</b> Firmware updates across major revisions (e.g., from 2.2.1 to 3.0.0) will trigger a factory reset. Please save a copy of your current configurations before proceeding.
         </div>
 
         <p id='msg'></p>


### PR DESCRIPTION
Per SEMVER standard, 'major revision' means going from 2.x.x to 3.0.0, not a patch update from 2.2.1 to 2.2.2. This corrects the example in the firmware update warning screen.

Fixes OpenSprinkler/OpenSprinkler-Firmware#426