### PR TITLE
Reset watering level to 100% when weather data is stale

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -2147,6 +2147,10 @@ void OpenSprinkler::options_setup() {
 /** Load non-volatile controller status data from file */
 void OpenSprinkler::nvdata_load() {
 	file_read_block(NVCON_FILENAME, &nvdata, 0, sizeof(NVConData));
+	// seed the in-RAM last-success time from nvdata so the stale-weather watchdog
+	// in check_weather() is not reset by a reboot (an old, shorter nvdata file
+	// reads this field back as 0, which is handled)
+	checkwt_success_lasttime = nvdata.weather_success_lasttime;
 	old_status = status;
 }
 

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -125,6 +125,7 @@ struct NVConData {
 	uint32_t external_ip;        // external ip
 	uint8_t  reboot_cause;       // reboot cause
 	uint16_t last_sensor_uuid;   // counter for sensor UUID generation; next sensor gets ++this
+	uint32_t weather_success_lasttime; // last time the weather service returned errCode==0 (0 = never)
 };
 
 struct StationAttrib {  // station attributes

--- a/main.cpp
+++ b/main.cpp
@@ -1107,29 +1107,41 @@ static bool process_special_program_command(const char* pname, uint32_t curr_tim
 
 /** Make weather query */
 void check_weather() {
-	// do not check weather if
-	// - network check has failed, or
-	// - the controller is in remote extension mode
-	if (os.status.network_fails>0 || os.iopts[IOPT_REMOTE_EXT_MODE]) return;
 	if (os.status.program_busy) return;
 
-	if (!os.network_connected()) return;
-
 	time_os_t ntz = os.now_tz();
-	if (os.checkwt_success_lasttime && (ntz > os.checkwt_success_lasttime + CHECK_WEATHER_SUCCESS_TIMEOUT)) {
-		// if last successful weather call timestamp is more than allowed threshold
-		// and if the selected adjustment method is not one of the manual methods
-		// reset watering percentage to 100
+
+	// If there has been no successful weather call within the allowed window,
+	// reset the watering level to 100%. This guards against a weather-service
+	// outage leaving watering stuck at a stale value - a 0% rain adjustment or an
+	// above-100% heat adjustment - long after the conditions that produced it.
+	// checkwt_success_lasttime is seeded from NVConData on boot, so a reboot does
+	// not restart the clock; powerup_lasttime is the fallback when the service has
+	// never been reached. This runs even when the network is down.
+	time_os_t last_success = os.checkwt_success_lasttime ? os.checkwt_success_lasttime : os.powerup_lasttime;
+	if (last_success && (ntz > last_success + CHECK_WEATHER_SUCCESS_TIMEOUT)) {
+		// if the selected adjustment method is not one of the manual methods
 		os.checkwt_success_lasttime = 0;
 		unsigned char method = os.iopts[IOPT_USE_WEATHER];
 		if(!(method==WEATHER_METHOD_MANUAL || method==WEATHER_METHOD_AUTORAINDELAY || method==WEATHER_METHOD_MONTHLY)) {
-			os.iopts[IOPT_WATER_PERCENTAGE] = 100; // reset watering percentage to 100%
+			if (os.iopts[IOPT_WATER_PERCENTAGE] != 100) {
+				os.iopts[IOPT_WATER_PERCENTAGE] = 100; // reset watering percentage to 100%
+				os.iopts_save(); // persist so a reboot does not restore the stale value
+				os.weather_update_flag |= WEATHER_UPDATE_WL; // notify the user of the reset
+			}
 			wt_restricted = 0; // reset wt_rawData, errCode, and md_scales array
 			wt_rawData[0] = 0;
 			wt_errCode = HTTP_RQT_NOT_RECEIVED;
 			md_N = 0;
 		}
-	} else if (!os.checkwt_lasttime || (ntz > os.checkwt_lasttime + CHECK_WEATHER_TIMEOUT)) {
+	}
+
+	// the weather query itself needs the network, and is not made in remote
+	// extension mode
+	if (os.status.network_fails>0 || os.iopts[IOPT_REMOTE_EXT_MODE]) return;
+	if (!os.network_connected()) return;
+
+	if (!os.checkwt_lasttime || (ntz > os.checkwt_lasttime + CHECK_WEATHER_TIMEOUT)) {
 		os.checkwt_lasttime = ntz;
 		#if defined(USE_DISPLAY)
 		if (!ui_state) {

--- a/weather.cpp
+++ b/weather.cpp
@@ -65,7 +65,15 @@ static void getweather_callback(char* buffer) {
 	// first check errCode, only update lswc timestamp if errCode is 0
 	if (findKeyVal(p, tmp_buffer, TMP_BUFFER_SIZE, PSTR("errCode"), true)) {
 		wt_errCode = atoi(tmp_buffer);
-		if(wt_errCode==0) os.checkwt_success_lasttime = tnow;
+		if(wt_errCode==0) {
+			os.checkwt_success_lasttime = tnow;
+			// persist the last-success time (rate-limited) so the stale-weather
+			// watchdog in check_weather() survives a reboot
+			if(tnow > os.nvdata.weather_success_lasttime + 3600) {
+				os.nvdata.weather_success_lasttime = tnow;
+				save_nvdata = true;
+			}
+		}
 	}
 
 	// then only parse scale if errCode is 0


### PR DESCRIPTION
check_weather() already resets the watering level to 100% when there has been no successful weather call for CHECK_WEATHER_SUCCESS_TIMEOUT (24h), so a stale weather adjustment - a 0% rain adjustment, or an above-100% heat adjustment - is not carried forward forever when the weather service is unreachable. That reset does not work in the cases that matter:

- It is gated on os.checkwt_success_lasttime, which is RAM-only and 0 after every reboot, and is only set on an errCode==0 response. So after a reboot during an outage (or a persistent errCode, or a controller that has never reached the service) the guard is never true. IOPT_WATER_PERCENTAGE *is* persisted, so the stale value survives while the mechanism to clear it does not.
- It sits behind the network_fails / network_connected() early-returns, so it never runs during the network outage that usually causes the problem.

Changes:

- NVConData gains weather_success_lasttime; getweather_callback() writes it (rate-limited to hourly, piggybacking the existing nvdata save) on every errCode==0 response, and nvdata_load() seeds checkwt_success_lasttime from it on boot. The 24h clock is now measured from the last actual contact, so a reboot - or a reboot loop - does not restart it. An old, shorter nvdata file reads the new field back as 0, which falls through to the powerup_lasttime fallback (same as before).

- check_weather(): the reset uses powerup_lasttime as the reference when there has been no successful call since boot, runs before the network / remote-extension early-returns so it works while offline, persists the reset via iopts_save() (guarded on an actual change), and sets WEATHER_UPDATE_WL so the user is notified. The program_busy guard stays first, so no flash write happens mid-program.

Manual / AutoRainDelay / Monthly methods and non-weather programs are unaffected. CHECK_WEATHER_SUCCESS_TIMEOUT (24h) is unchanged.